### PR TITLE
Fix GCD series matching: dead tokenized variation, unguarded one-token fallback, unapplied year

### DIFF
--- a/models/gcd.py
+++ b/models/gcd.py
@@ -23,6 +23,15 @@ STOPWORDS = {"the", "a", "an", "of", "and", "vol", "volume", "season", "series"}
 # unanchored substring. They are the only ones broad enough to need a guard.
 MAIN_WORD_VARIATIONS = frozenset({"main_only", "main_with_year"})
 
+# Variations that constrain results to series actually running in the parsed
+# year, when the filename supplied one. `main_with_year` is included because
+# that is what its name promises; `main_only` is what the same variation is
+# called when no year is available. `tokenized` is deliberately absent -- it
+# runs through the REGEXP branch, which has no year clause.
+YEAR_CONSTRAINED_VARIATIONS = frozenset({
+    "exact", "no_issue", "no_year", "no_dash", "main_with_year",
+})
+
 # How many candidate series the main-word fallback may match and still be
 # treated as evidence. The loop only ever inspects the first row, so beyond a
 # handful of candidates "first by year" is an arbitrary pick rather than a best
@@ -501,11 +510,39 @@ def search_series(series_name: str, year: int = None, language_codes: List[str] 
                     ' LEFT JOIN gcd_publisher p ON s.publisher_id = p.id'
                 )
                 lang_filter = ' AND l.code IN (' + lang_placeholders + ')'
-                # The main-word fallback is checked against one extra row so an
-                # over-broad token can be recognised as such -- see below.
-                row_limit = (MAIN_WORD_MAX_CANDIDATES + 1
-                             if search_type in MAIN_WORD_VARIATIONS else 10)
-                order_suffix = f' ORDER BY s.year_began DESC LIMIT {row_limit}'
+                order_suffix = ' ORDER BY s.year_began DESC LIMIT 10'
+
+                # The main-word fallback searches a single token as an unanchored
+                # substring, so a short or common token matches an enormous slice
+                # of the database -- '%le%' matches 18,526 series in the current
+                # dump. Ordering those by year and taking the first does not pick
+                # the best candidate, it picks the most recently started one, which
+                # is how an Italian Disney part-work ends up tagged as a 2026
+                # Harley Quinn book. When the token cannot narrow the field to
+                # something rankable, decline instead of guessing.
+                #
+                # The probe deliberately ignores the year filter. How
+                # discriminating a token is, is a property of the token: '%diabolik%'
+                # matches 15 series whichever year is asked for. Measuring the
+                # year-filtered set instead would let the year clause shrink an
+                # over-broad token under the cap and hand back an arbitrary pick
+                # from whatever happened to be running that year.
+                if search_type in MAIN_WORD_VARIATIONS:
+                    cursor.execute(
+                        'SELECT 1 FROM gcd_series s'
+                        ' JOIN stddata_language l ON s.language_id = l.id'
+                        ' WHERE s.name LIKE ?' + lang_filter
+                        + f' LIMIT {MAIN_WORD_MAX_CANDIDATES + 1}',
+                        (search_pattern, *language_codes),
+                    )
+                    if len(cursor.fetchall()) > MAIN_WORD_MAX_CANDIDATES:
+                        app_logger.info(
+                            f"GCD search_series: Skipping {search_type} for "
+                            f"'{series_name}' -- '{search_pattern}' matches more "
+                            f"than {MAIN_WORD_MAX_CANDIDATES} series, too broad "
+                            f"to rank"
+                        )
+                        continue
 
                 if search_type == "tokenized":
                     # REGEXP search
@@ -513,8 +550,12 @@ def search_series(series_name: str, year: int = None, language_codes: List[str] 
                              + ' WHERE LOWER(s.name) REGEXP ?'
                              + lang_filter + order_suffix)
                     cursor.execute(query, (search_pattern.lower(), *language_codes))
-                elif year and search_type in ["exact", "no_issue", "no_year", "no_dash"]:
-                    # Year-constrained LIKE search
+                elif year and search_type in YEAR_CONSTRAINED_VARIATIONS:
+                    # Year-constrained LIKE search. `main_with_year` belongs here:
+                    # it was named for a year it never applied, because it was
+                    # missing from this list and fell through to the plain LIKE
+                    # below -- which is how a file dated 1987 matched a 2026
+                    # series while the log line read "using main_with_year".
                     query = (base_select
                              + ' WHERE s.name LIKE ?'
                              + ' AND s.year_began <= ?'
@@ -529,23 +570,6 @@ def search_series(series_name: str, year: int = None, language_codes: List[str] 
                     cursor.execute(query, (search_pattern, *language_codes))
 
                 results = cursor.fetchall()
-
-                # The main-word fallback searches a single token as an unanchored
-                # substring, so a short or common token matches an enormous slice
-                # of the database -- '%le%' matches 18,526 series in the current
-                # dump. Ordering those by year and taking the first does not pick
-                # the best candidate, it picks the most recently started one, which
-                # is how an Italian Disney part-work ends up tagged as a 2026
-                # Harley Quinn book. When the token cannot narrow the field to
-                # something rankable, decline instead of guessing.
-                if search_type in MAIN_WORD_VARIATIONS and len(results) > MAIN_WORD_MAX_CANDIDATES:
-                    app_logger.info(
-                        f"GCD search_series: Skipping {search_type} for "
-                        f"'{series_name}' -- '{search_pattern}' matches more than "
-                        f"{MAIN_WORD_MAX_CANDIDATES} series, too broad to rank"
-                    )
-                    continue
-
                 if results:
                     # Auto-select the best match (first result, sorted by year)
                     series_result = results[0]

--- a/models/gcd.py
+++ b/models/gcd.py
@@ -19,6 +19,17 @@ from core.app_logging import app_logger
 
 STOPWORDS = {"the", "a", "an", "of", "and", "vol", "volume", "season", "series"}
 
+# The last-resort search variations, which look up a single token as an
+# unanchored substring. They are the only ones broad enough to need a guard.
+MAIN_WORD_VARIATIONS = frozenset({"main_only", "main_with_year"})
+
+# How many candidate series the main-word fallback may match and still be
+# treated as evidence. The loop only ever inspects the first row, so beyond a
+# handful of candidates "first by year" is an arbitrary pick rather than a best
+# match. Raising this does not improve matching -- it only makes wrong matches
+# more likely.
+MAIN_WORD_MAX_CANDIDATES = 10
+
 # Full set of GCD tables CLU touches across all code paths. Used to detect
 # which auxiliary tables a particular dump excludes — the public dump
 # from comics.org periodically drops tables (e.g. gcd_creator, gcd_issue_credit)
@@ -490,7 +501,11 @@ def search_series(series_name: str, year: int = None, language_codes: List[str] 
                     ' LEFT JOIN gcd_publisher p ON s.publisher_id = p.id'
                 )
                 lang_filter = ' AND l.code IN (' + lang_placeholders + ')'
-                order_suffix = ' ORDER BY s.year_began DESC LIMIT 10'
+                # The main-word fallback is checked against one extra row so an
+                # over-broad token can be recognised as such -- see below.
+                row_limit = (MAIN_WORD_MAX_CANDIDATES + 1
+                             if search_type in MAIN_WORD_VARIATIONS else 10)
+                order_suffix = f' ORDER BY s.year_began DESC LIMIT {row_limit}'
 
                 if search_type == "tokenized":
                     # REGEXP search
@@ -514,6 +529,23 @@ def search_series(series_name: str, year: int = None, language_codes: List[str] 
                     cursor.execute(query, (search_pattern, *language_codes))
 
                 results = cursor.fetchall()
+
+                # The main-word fallback searches a single token as an unanchored
+                # substring, so a short or common token matches an enormous slice
+                # of the database -- '%le%' matches 18,526 series in the current
+                # dump. Ordering those by year and taking the first does not pick
+                # the best candidate, it picks the most recently started one, which
+                # is how an Italian Disney part-work ends up tagged as a 2026
+                # Harley Quinn book. When the token cannot narrow the field to
+                # something rankable, decline instead of guessing.
+                if search_type in MAIN_WORD_VARIATIONS and len(results) > MAIN_WORD_MAX_CANDIDATES:
+                    app_logger.info(
+                        f"GCD search_series: Skipping {search_type} for "
+                        f"'{series_name}' -- '{search_pattern}' matches more than "
+                        f"{MAIN_WORD_MAX_CANDIDATES} series, too broad to rank"
+                    )
+                    continue
+
                 if results:
                     # Auto-select the best match (first result, sorted by year)
                     series_result = results[0]

--- a/models/gcd.py
+++ b/models/gcd.py
@@ -66,7 +66,11 @@ def lookahead_regex(toks):
     Works with MySQL REGEXP and is case-insensitive when we pass 'i' or pre-lowercase."""
     if not toks:
         return r".*"          # match-all fallback
-    parts = [rf"(?=.*\\b{re.escape(t)}\\b)" for t in toks]
+    # The word boundary is a single backslash-b. Writing it as ``\\b`` inside a
+    # *raw* string emits a literal backslash followed by 'b', which matches only
+    # a series name containing a backslash -- so the variation never matched and
+    # every multi-word title fell through to the one-token fallback below.
+    parts = [rf"(?=.*\b{re.escape(t)}\b)" for t in toks]
     return "^" + "".join(parts) + ".*$"
 
 

--- a/tests/mocked/test_gcd_model.py
+++ b/tests/mocked/test_gcd_model.py
@@ -363,3 +363,69 @@ class TestValidateIssue:
         from models.gcd import validate_issue
         result = validate_issue(None, None)
         assert result["success"] is False
+
+
+class TestMainWordYearConstraint:
+    """A year in the filename must actually filter the main-word fallback."""
+
+    def test_year_outside_the_series_run_is_rejected(self, gcd_configured):
+        from models.gcd import search_series
+        # Batman began in 1940; a 1930 file predates it, so the fallback that
+        # would otherwise return it must find nothing.
+        assert search_series("Batman Adventures Special Edition", year=1930) is None
+
+    def test_year_inside_the_series_run_still_matches(self, gcd_configured):
+        from models.gcd import search_series
+        result = search_series("Batman Adventures Special Edition", year=1975)
+        assert result is not None
+        assert result["name"] == "Batman"
+
+    def test_no_year_leaves_the_fallback_unconstrained(self, gcd_configured):
+        from models.gcd import search_series
+        result = search_series("Batman Adventures Special Edition")
+        assert result is not None
+        assert result["name"] == "Batman"
+
+
+class TestMainWordProbeIgnoresTheYear:
+    """The breadth probe must measure the token, not the year-filtered slice.
+
+    Regression guard: when the probe was run against the year-constrained query,
+    a year clause could shrink an over-broad token under the cap, and the
+    fallback went back to returning an arbitrary series from whatever happened
+    to be running that year. In the real dump '%diabolik%' matches 15 series but
+    only 4 running in 2014.
+    """
+
+    @pytest.fixture
+    def many_zorros(self, tmp_path, monkeypatch):
+        path = build_gcd_sqlite(tmp_path / "zorro.db")
+        conn = sqlite3.connect(path)
+        conn.executemany(
+            "INSERT INTO gcd_series (id, name, year_began, year_ended, "
+            "publisher_id, language_id) VALUES (?, ?, ?, ?, ?, ?)",
+            [(300, "Zorro", 1950, None, 10, 1),
+             (301, "Zorro Rides Again", 1990, 1995, 10, 1),
+             (302, "Zorro Returns", 2020, None, 10, 1)],
+        )
+        conn.commit()
+        conn.close()
+        monkeypatch.setattr("models.gcd._get_saved_credentials",
+                            lambda: {"database_path": str(path)})
+        return path
+
+    def test_year_filter_cannot_rescue_an_over_broad_token(self, many_zorros,
+                                                           monkeypatch):
+        import models.gcd as gcd
+        # Three series contain 'zorro'; only one of them was running in 1955.
+        monkeypatch.setattr(gcd, "MAIN_WORD_MAX_CANDIDATES", 2)
+        assert gcd.search_series("Zorro Special Annual Edition", year=1955) is None
+
+    def test_a_token_within_the_cap_is_still_year_constrained(self, many_zorros,
+                                                              monkeypatch):
+        import models.gcd as gcd
+        monkeypatch.setattr(gcd, "MAIN_WORD_MAX_CANDIDATES", 5)
+        result = gcd.search_series("Zorro Special Annual Edition", year=1955)
+        assert result is not None
+        # 'Zorro Returns' (2020) is the newest, but it was not running in 1955.
+        assert result["name"] == "Zorro"

--- a/tests/mocked/test_gcd_model.py
+++ b/tests/mocked/test_gcd_model.py
@@ -102,6 +102,33 @@ class TestSearchSeries:
         from models.gcd import search_series
         assert search_series("Batman") is None
 
+    def test_main_word_fallback_still_matches_a_narrow_token(self, gcd_configured):
+        """`Batman` matches one series here, so the fallback stays useful."""
+        from models.gcd import search_series
+        result = search_series("Batman Adventures Special Edition")
+        assert result is not None
+        assert result["name"] == "Batman"
+
+    def test_main_word_fallback_declines_an_over_broad_token(self, gcd_configured,
+                                                             monkeypatch):
+        """Beyond the candidate cap the first row is an arbitrary pick, not a match.
+
+        Simulated by lowering the cap rather than loading thousands of series:
+        the real dump has 18,526 series containing 'le'.
+        """
+        import models.gcd as gcd
+        monkeypatch.setattr(gcd, "MAIN_WORD_MAX_CANDIDATES", 0)
+        assert gcd.search_series("Batman Adventures Special Edition") is None
+
+    def test_the_cap_does_not_apply_to_the_precise_variations(self, gcd_configured,
+                                                              monkeypatch):
+        """An exact hit must survive a cap of zero -- only the fallback is guarded."""
+        import models.gcd as gcd
+        monkeypatch.setattr(gcd, "MAIN_WORD_MAX_CANDIDATES", 0)
+        result = gcd.search_series("Batman")
+        assert result is not None
+        assert result["name"] == "Batman"
+
 
 class TestConfiguredLanguages:
     """The gcd_metadata_languages preference must reach every lookup path."""

--- a/tests/unit/test_gcd_search_variations.py
+++ b/tests/unit/test_gcd_search_variations.py
@@ -112,3 +112,28 @@ class TestMainWordGuardConstants:
         from models.gcd import MAIN_WORD_MAX_CANDIDATES
         assert isinstance(MAIN_WORD_MAX_CANDIDATES, int)
         assert MAIN_WORD_MAX_CANDIDATES > 0
+
+
+class TestYearConstrainedVariations:
+    """`main_with_year` was named for a year it never applied."""
+
+    def test_main_with_year_is_year_constrained(self):
+        from models.gcd import YEAR_CONSTRAINED_VARIATIONS
+        assert "main_with_year" in YEAR_CONSTRAINED_VARIATIONS
+
+    def test_main_only_is_not(self):
+        """There is no year to constrain by when the filename carried none."""
+        from models.gcd import YEAR_CONSTRAINED_VARIATIONS
+        assert "main_only" not in YEAR_CONSTRAINED_VARIATIONS
+
+    def test_tokenized_is_not(self):
+        """It runs through the REGEXP branch, which has no year clause."""
+        from models.gcd import YEAR_CONSTRAINED_VARIATIONS
+        assert "tokenized" not in YEAR_CONSTRAINED_VARIATIONS
+
+    def test_every_constrained_name_is_a_variation_the_builder_can_emit(self):
+        from models.gcd import YEAR_CONSTRAINED_VARIATIONS
+        emitted = set()
+        for title in ["Batman Detective 001", "Batman - Detective (2016)"]:
+            emitted.update(t for t, _ in generate_search_variations(title, "2016"))
+        assert YEAR_CONSTRAINED_VARIATIONS <= emitted

--- a/tests/unit/test_gcd_search_variations.py
+++ b/tests/unit/test_gcd_search_variations.py
@@ -1,0 +1,94 @@
+"""Tests for the GCD search-variation builders in models/gcd.py.
+
+These are pure functions -- no database needed -- so they live in unit tests.
+"""
+import re
+
+import pytest
+
+from models.gcd import (
+    generate_search_variations,
+    lookahead_regex,
+    normalize_title,
+    tokens_for_all_match,
+)
+
+
+class TestNormalizeTitle:
+    def test_lowercases_and_strips_punctuation(self):
+        assert normalize_title("Superman: The Secret Years!") == "superman the secret years"
+
+    def test_collapses_whitespace(self):
+        assert normalize_title("Batman   -   Detective") == "batman detective"
+
+
+class TestTokensForAllMatch:
+    def test_drops_english_stopwords(self):
+        _, toks = tokens_for_all_match("Superman and the Secret Years")
+        assert toks == ["superman", "secret", "years"]
+
+    def test_keeps_non_stopwords_in_order(self):
+        _, toks = tokens_for_all_match("Le Grandi Storie Walt Disney")
+        assert toks[0] == "le"
+
+
+class TestLookaheadRegex:
+    """The escaping here decides whether the `tokenized` variation works at all."""
+
+    def test_emits_a_real_word_boundary_not_a_literal_backslash(self):
+        pattern = lookahead_regex(["superman", "secret"])
+        assert r"\\b" not in pattern
+        assert r"\b" in pattern
+
+    def test_matches_a_series_containing_every_token(self):
+        pattern = lookahead_regex(["superman", "secret", "years"])
+        assert re.search(pattern, "superman: the secret years")
+
+    def test_matches_regardless_of_token_order(self):
+        pattern = lookahead_regex(["years", "superman"])
+        assert re.search(pattern, "superman: the secret years")
+
+    def test_does_not_match_when_a_token_is_missing(self):
+        pattern = lookahead_regex(["superman", "secret", "decades"])
+        assert not re.search(pattern, "superman: the secret years")
+
+    def test_word_boundary_rejects_a_substring_hit(self):
+        """`bat` must not match `batman` -- that is the point of the boundary."""
+        pattern = lookahead_regex(["bat"])
+        assert not re.search(pattern, "batman")
+        assert re.search(pattern, "bat out of hell")
+
+    def test_empty_tokens_fall_back_to_match_all(self):
+        assert lookahead_regex([]) == r".*"
+
+    def test_regex_metacharacters_in_a_token_are_escaped(self):
+        """`tokens_for_all_match` normalises these away, but the escaping must
+        still hold so a stray token cannot blow up the query."""
+        pattern = lookahead_regex(["c++"])
+        re.compile(pattern)          # must not raise
+        assert r"c\+\+" in pattern
+
+
+class TestGenerateSearchVariations:
+    def test_exact_is_always_first(self):
+        variations = generate_search_variations("Batman")
+        assert variations[0] == ("exact", "%Batman%")
+
+    def test_tokenized_offered_for_multi_token_titles(self):
+        names = [t for t, _ in generate_search_variations("Superman The Secret Years")]
+        assert "tokenized" in names
+
+    def test_tokenized_not_offered_for_a_single_token_title(self):
+        names = [t for t, _ in generate_search_variations("Topomistery")]
+        assert "tokenized" not in names
+
+    def test_tokenized_pattern_matches_the_real_series_name(self):
+        """The regression that mattered: this returned nothing for every title."""
+        pattern = dict(generate_search_variations("Superman The Secret Years"))["tokenized"]
+        assert re.search(pattern, "superman: the secret years")
+
+    def test_year_labels_the_main_word_variation(self):
+        with_year = [t for t, _ in generate_search_variations("Batman Detective", "2016")]
+        without = [t for t, _ in generate_search_variations("Batman Detective")]
+        assert "main_with_year" in with_year
+        assert "main_only" in without

--- a/tests/unit/test_gcd_search_variations.py
+++ b/tests/unit/test_gcd_search_variations.py
@@ -92,3 +92,23 @@ class TestGenerateSearchVariations:
         without = [t for t, _ in generate_search_variations("Batman Detective")]
         assert "main_with_year" in with_year
         assert "main_only" in without
+
+
+class TestMainWordGuardConstants:
+    """The fallback guard is a policy the rest of the module depends on."""
+
+    def test_only_the_main_word_variations_are_guarded(self):
+        from models.gcd import MAIN_WORD_VARIATIONS
+        assert MAIN_WORD_VARIATIONS == {"main_only", "main_with_year"}
+
+    def test_every_guarded_name_is_a_variation_the_builder_can_emit(self):
+        from models.gcd import MAIN_WORD_VARIATIONS
+        emitted = set()
+        for title, year in [("Batman Detective", "2016"), ("Batman Detective", None)]:
+            emitted.update(t for t, _ in generate_search_variations(title, year))
+        assert MAIN_WORD_VARIATIONS <= emitted
+
+    def test_candidate_cap_is_a_positive_int(self):
+        from models.gcd import MAIN_WORD_MAX_CANDIDATES
+        assert isinstance(MAIN_WORD_MAX_CANDIDATES, int)
+        assert MAIN_WORD_MAX_CANDIDATES > 0


### PR DESCRIPTION
## 📝 Description
Closes #517

Three independent defects in `models/gcd.py` that combine to turn "CLU cannot match this title"
into "CLU tags this file with the wrong series". One commit each — split them if you would rather
they land apart, and the order matters only between 2 and 3 (see below).

**This implements the four options put to you in #517 in one particular way.** If you would rather
have a different candidate cap, or drop the main-word fallback entirely now that `tokenized`
works, say so and I will rework it.

### 1. `lookahead_regex` emitted a literal backslash (`8497fa9`)

The pattern was built with `\\b` inside a **raw** f-string, so the regex handed to SQLite required
a literal backslash in the series name. `tokenized` has never matched anything, for any library,
in any language. The docstring directly above shows the intended pattern — it is a normal,
non-raw string where `\\b` renders as `\b`, which is likely how the escaping got in.

The consequence was not a missing variation but a wrong match: every multi-word title that is not
a literal substring of a GCD series name fell through to the one-token fallback below.

### 2. The main-word fallback had no floor (`5afb895`)

`main_only` / `main_with_year` substring-match the title's first token and take the first row of
`ORDER BY year_began DESC LIMIT 10`. In the 2026-08-22 dump `%le%` matches 18,526 series, `%la%`
12,581 and `%i%` 79,986 — so that first row is not the best candidate, it is the most recently
started one. The loop only ever inspects one row, so past a handful of candidates there is nothing
to rank with. New `MAIN_WORD_MAX_CANDIDATES = 10`: over that, log why and decline.

Only the two main-word variations are guarded. `exact`, `no_issue`, `no_year`, `no_dash` and
`tokenized` keep their existing behaviour.

### 3. `main_with_year` never applied the year (`f02615a`)

The year-constrained branch listed `exact`, `no_issue`, `no_year`, `no_dash`. `main_with_year` was
missing, so it fell through to the plain LIKE — the `year` argument only ever changed the label in
the log line. That is why the log in #510 reads `Found 'Diabolik' (1999) using main_with_year` for
a file dated 2014. The list literal is now a named `YEAR_CONSTRAINED_VARIATIONS` so an omission is
visible rather than implicit.

> **Worth your attention: 2 and 3 interact, and the obvious ordering is wrong.**
> My first attempt applied the year while the breadth probe still measured the *year-filtered*
> result set, and it reintroduced three wrong matches. A year clause shrinks the candidate set, so
> it pushes an over-broad token back under the cap and switches the guard off exactly where it is
> needed: `%diabolik%` matches 15 series unconstrained but only 4 running in 2014; `%albo%` is 59
> vs 1. The probe therefore runs **unconstrained** — how discriminating a token is, is a property
> of the token, not of the year being asked for. Two tests pin this down, because it would be easy
> to reintroduce.

## 🛠️ Changes Made
- [x] Added new feature logic — `models/gcd.py`: `lookahead_regex` escaping, new
      `MAIN_WORD_VARIATIONS` / `MAIN_WORD_MAX_CANDIDATES` breadth probe, new
      `YEAR_CONSTRAINED_VARIATIONS`
- [x] Updated Docker/Config if necessary — not needed, no new settings
- [ ] Verified build locally (`docker build -t dev .`) — image built from `main` for testing, but
      no dependency or image change in this branch

## 📸 Screenshots / Logs

Measured in a container built from `main` @ `0fdd2dd`, driving CLU's own `extract_comic_values`
and `search_series` over 32 real files against the 2026-08-22 comics.org dump, languages `it,en`.
Each fix was applied and evaluated on its own.

**Fix 1 — 4 changes, every one wrong → correct:**

| File | Before | After |
| --- | --- | --- |
| Le Grandi Storie Walt Disney 01 | Harley & Ivy: Life & Crimes (2026) | **Le Grandi Storie Di Walt Disney (1987)** |
| Superman The Secret Years 01 | DC K.O.: Superman vs. Captain Atom (2026) | **Superman: The Secret Years (1985)** |
| Batman Detective Comics Rebirth 01 | Batman / Green Arrow / The Question (2026) | **Batman: Detective Comics – Rebirth (2018)** |
| Amazing Spider-Man Renew Your Vows 01 | Treasury Edition 50th Anniversary (2026) | **Amazing Spider-Man: Renew Your Vows (2017)** |

**Fix 2 — 16 changes, every one a wrong match → no match, no correct match lost.** Representative:

```
I classici di Walt Disney 001   Space Ghost Volume Two (2026)        -> none
Disney Comics 03                Disney Hercules (2026)               -> none
La Grande Scienza Disney 01     Spider-Man: Holiday Spectacular (2026)-> none
Diabolik - Nero Su Nero #001    Diabolik: il re del terrore remake   -> none
Albo d'oro v2 002               Bryan Talbot's Brainstorm (2024)     -> none
```

**Fix 3 — 1 change:** `2000AD 1795 (2018)` → Best of 2000AD (2022) → none. Correct: that series
began four years after the file is dated.

**Cumulative: 28 of 32 files matched before, 11 after. All 17 dropped were wrong series.**
The survivors are the ones that were already right — Le Grandi Storie Di Walt Disney (1987) via
`tokenized`, and I Classici di Walt Disney (1977), Topomistery (1991), Disney Noir (2018),
Disney Time (1994) via `exact`.

## 🧪 Testing Performed
- [x] Manual test in `dev` container — not the dev container, but the real `models.gcd` +
      `cbz_ops.rename` code paths in a container built from this branch; see above
- [x] Linting/Unit tests pass — **4201 passed**

New tests: `tests/unit/test_gcd_search_variations.py` (23) covering the word boundary being real,
order independence, `bat` not matching `batman`, metacharacter escaping, and the guard constants
being names the builder can actually emit; `tests/mocked/test_gcd_model.py` (10) covering the
fallback still matching a narrow token, declining an over-broad one, the cap not touching the
precise variations, the year constraint on `main_with_year`, and the probe's year-independence.

**One thing to flag on the suite.** 10 tests fail in my container —
`tests/routes/test_folder_access.py` and `tests/routes/test_library_access.py`, all multi-user
access control. They fail identically on a clean checkout of `main` in the same container, so they
are environmental rather than caused by this branch, but I could not reach the 100% pass rate
`CLAUDE.md` asks for and did not want to claim otherwise.

## Not in this PR

Two files in the sample still match the wrong series, and neither comes from the code this PR
touches — both come from `exact`, which is an unanchored `LIKE %name%`, so a longer series name
containing the parsed one wins:

```
Saga 012 (2013)         -> Michael Turner's Fathom: The Elite Saga (2013)
Action Comics 1000 (2018) -> Superman: Action Comics: The Oz Effect - Deluxe Edition (2018)
```

Happy to open that separately if you would like it looked at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
