### PR TITLE
Stop tagging files from stale Metron cache and backfill the impacted issues

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -120,6 +120,7 @@ CLU is a comic metadata editor as well as a file tool. Metadata is written to `C
 - **Create ComicInfo.xml when missing**, and a missing-XML view with rescan.
 - **Batch field updates** — set or clear specific ComicInfo fields across many files in parallel.
 - **Write from database** — push metadata already indexed in CLU back into the files.
+- **Creator credit backfill** — Metron often finishes an issue record hours after the comic ships, so a file tagged on release morning can land with no creators at all. CLU re-checks recently tagged files after each series sync (or on demand from Schedules) and fills the credits in, keeping the tags the file already has.
 - Provider-ID stripping from credits, and clickable Writer / Penciller / Character links in the issue info modal.
 
 📖 [Metadata provider settings](https://clucomics.org/features/app-settings/metadata/) · [Source Wall](https://clucomics.org/features/collection/source-wall/) · [ComicInfo.xml options](https://clucomics.org/features/file-management/comicinfo/) · [Local databases](https://clucomics.org/features/local-databases/)

--- a/app.py
+++ b/app.py
@@ -658,6 +658,20 @@ def scheduled_series_sync():
             f"✅ Sync completed: {success_count} updated, {skip_count} skipped, {fail_count} failed in {elapsed:.2f}s"
         )
 
+        # Repair files tagged from a half-entered Metron record. Credits are
+        # routinely added hours after a comic ships, and once ComicInfo carries
+        # Notes nothing re-tags the file, so this is the only thing that fixes
+        # them. Isolated: a backfill problem must never fail the sync.
+        try:
+            if get_user_preference("credit_backfill_enabled", default=True):
+                from core.credit_backfill import run_credit_backfill
+
+                run_credit_backfill(app=app)
+            else:
+                app_logger.debug("Credit backfill disabled by preference")
+        except Exception as e:
+            app_logger.error(f"Credit backfill sweep failed: {e}")
+
     except Exception as e:
         app_logger.error(f"Scheduled series sync failed: {e}")
 

--- a/core/credit_backfill.py
+++ b/core/credit_backfill.py
@@ -1,0 +1,304 @@
+"""Repair Metron-tagged comics that were written with no creator credits.
+
+Metron records are routinely completed *after* a comic ships -- credits and
+characters get entered hours into release day -- so a file tagged the morning it
+lands can end up with a perfectly valid ComicInfo.xml that simply has no
+creators in it. Nothing recovers that on its own: once ComicInfo carries a
+``Notes`` value, every automatic tagging path treats the file as done and skips
+it forever (``app.py``, ``models/comicvine.py``, ``routes/metadata.py``).
+
+This sweep is the recovery. It picks credit-less files out of ``file_index``
+(no archive I/O to find them), re-fetches each issue from Metron through
+``metron.fetch_issue_detail`` -- which drops mokkari's cached body first, or the
+half-entered response would just be replayed -- and rewrites only the files
+where Metron now actually has credits.
+
+Two deliberate limits keep it cheap and self-terminating:
+
+* Candidates are restricted to files whose **mtime** is recent. mtime only moves
+  when the archive is rewritten, so a comic Metron will never have credits for
+  ages out of the window instead of being re-fetched every night.
+  ``metadata_scanned_at`` would be wrong here -- the scanner refreshes it.
+* A file is rewritten only when the fresh payload really has credits, so a run
+  that finds nothing new touches no bytes and no mtimes.
+"""
+
+import os
+import time
+from typing import Any, Dict, List, Optional
+
+from core.app_logging import app_logger
+
+# ComicInfo credit tags this sweep cares about, in ComicInfo and file_index
+# spellings. Editor/Translator are excluded on purpose: the Metron mapper does
+# not produce them, so their absence says nothing about whether a file is
+# missing credits.
+CREDIT_TAGS = ("Writer", "Penciller", "Inker", "Colorist", "Letterer", "CoverArtist")
+_CREDIT_COLUMNS = (
+    "ci_writer",
+    "ci_penciller",
+    "ci_inker",
+    "ci_colorist",
+    "ci_letterer",
+    "ci_coverartist",
+)
+
+DEFAULT_DAYS = 45
+# Metron fetches per run. Paced at ~15 requests/minute, so this is also what
+# bounds how long a sweep runs.
+DEFAULT_LIMIT = 200
+# Files examined per run. Opening an archive is free next to an API call, and
+# most candidates turn out not to be Metron-tagged at all -- without the wider
+# scan those would fill the query's LIMIT every night and starve the files that
+# actually need fetching.
+SCAN_MULTIPLIER = 5
+MAX_SCAN = 1000
+
+
+def _has_credits(mapping: Dict[str, Any]) -> bool:
+    """True when any ComicInfo credit field carries a non-empty value."""
+    return any(str(mapping.get(tag) or "").strip() for tag in CREDIT_TAGS)
+
+
+def find_credit_less_files(
+    days: int = DEFAULT_DAYS, limit: int = DEFAULT_LIMIT
+) -> List[str]:
+    """Recently written CBZs whose indexed metadata has no creator credits.
+
+    Args:
+        days: Only consider files modified within this many days.
+        limit: Maximum number of paths to return.
+
+    Returns:
+        List of file paths, newest first. Empty on any database problem.
+    """
+    from core.database import get_db_connection
+
+    cutoff = time.time() - (max(1, int(days)) * 86400)
+    empties = " AND ".join(f"COALESCE({col}, '') = ''" for col in _CREDIT_COLUMNS)
+
+    try:
+        conn = get_db_connection()
+        if not conn:
+            return []
+        rows = conn.execute(
+            f"""
+            SELECT path FROM file_index
+            WHERE type = 'file'
+              AND has_comicinfo = 1
+              AND LOWER(path) LIKE '%.cbz'
+              AND {empties}
+              AND modified_at >= ?
+            ORDER BY modified_at DESC
+            LIMIT ?
+            """,
+            (cutoff, max(1, int(limit))),
+        ).fetchall()
+        conn.close()
+        return [row[0] for row in rows]
+    except Exception as e:
+        app_logger.error(f"Credit backfill could not list candidates: {e}")
+        return []
+
+
+def _resolve_metron_issue(api, file_path: str, existing: Dict[str, Any]):
+    """Identify the Metron issue behind an already-tagged file.
+
+    ``<MetronId>`` is written by ``generate_comicinfo_xml``, but files tagged
+    before that tag existed only carry the Metron ``Notes`` line, whose resource
+    URL is a slug rather than an id -- those fall back to a lookup by the
+    folder's cvinfo series id and the file's issue number.
+
+    Returns:
+        ``(issue_id, payload)``. ``payload`` is the already-fetched issue data
+        when the fallback lookup had to fetch it anyway (it goes through
+        ``get_issue_metadata``, so it is live, not cached) and None otherwise.
+        ``(None, None)`` when the file wasn't tagged from Metron or the issue
+        can't be identified.
+    """
+    raw = str(existing.get("MetronId") or "").strip()
+    if raw:
+        try:
+            return int(raw), None
+        except (TypeError, ValueError):
+            pass
+
+    notes = str(existing.get("Notes") or "")
+    if "metron" not in notes.lower():
+        return None, None
+
+    number = str(existing.get("Number") or "").strip()
+    if not number:
+        return None, None
+
+    from models import metron
+    from models.comicvine import find_cvinfo_in_folder
+
+    cvinfo_path = find_cvinfo_in_folder(os.path.dirname(file_path))
+    if not cvinfo_path:
+        return None, None
+    series_id = metron.parse_cvinfo_for_metron_id(cvinfo_path)
+    if not series_id:
+        return None, None
+
+    issue_data = metron.get_issue_metadata(api, series_id, number)
+    if not issue_data:
+        return None, None
+    try:
+        return int(metron._get_attr(issue_data, "id", None)), issue_data
+    except (TypeError, ValueError):
+        return None, None
+
+
+def backfill_file(api, file_path: str, dry_run: bool = False) -> str:
+    """Re-fetch one file's Metron issue and add credits if Metron now has them.
+
+    Returns one of ``'updated'``, ``'still-empty'``, ``'skipped'``, ``'error'``.
+    """
+    from core.comicinfo import read_comicinfo_from_zip
+
+    try:
+        if not os.path.isfile(file_path):
+            return "skipped"
+
+        existing = read_comicinfo_from_zip(file_path) or {}
+        if not existing:
+            return "skipped"
+        # The index row can be stale; the archive is the authority.
+        if _has_credits(existing):
+            return "skipped"
+
+        issue_id, issue = _resolve_metron_issue(api, file_path, existing)
+        if not issue_id:
+            return "skipped"
+
+        from models import metron
+
+        if issue is None:
+            issue = metron.fetch_issue_detail(
+                api, issue_id, context="(credit backfill)"
+            )
+        if issue is None:
+            return "error"
+
+        metadata = metron.map_to_comicinfo(issue)
+        if not _has_credits(metadata):
+            # Metron still has no creators for this issue. Leave the file
+            # untouched so its mtime stays put and it ages out of the window.
+            return "still-empty"
+
+        if dry_run:
+            return "updated"
+
+        from core.comicinfo import generate_comicinfo_xml
+        from core.database import update_file_index_from_comicinfo
+        from models.comicvine import add_comicinfo_to_archive
+
+        xml_content = generate_comicinfo_xml(metadata)
+        # merge_existing (the default) matters here: the sweep adds credits, it
+        # must not drop tags the file already carries that Metron doesn't supply.
+        if not add_comicinfo_to_archive(file_path, xml_content):
+            return "error"
+
+        update_file_index_from_comicinfo(file_path, metadata)
+        app_logger.info(
+            f"Credit backfill: added credits to {os.path.basename(file_path)} "
+            f"(Metron issue {issue_id})"
+        )
+        return "updated"
+    except Exception as e:
+        app_logger.error(f"Credit backfill failed for {file_path}: {e}")
+        return "error"
+
+
+def run_credit_backfill(
+    days: int = DEFAULT_DAYS,
+    limit: int = DEFAULT_LIMIT,
+    dry_run: bool = False,
+    app=None,
+    on_progress=None,
+) -> Dict[str, Any]:
+    """Sweep recently tagged, credit-less files and repair the ones Metron can.
+
+    Args:
+        days: Only consider files modified within this many days.
+        limit: Maximum number of files to fetch from Metron in one run.
+        dry_run: Report what would change without writing anything.
+        app: Flask app to read Metron credentials from (defaults to
+            ``current_app``, so a scheduled caller should pass it explicitly).
+        on_progress: Optional ``(current, total, filename)`` callback, invoked
+            once per file. Metron pacing means a full run takes minutes, so the
+            manual trigger needs something to report while it works.
+
+    Returns:
+        Summary counts plus ``stopped_early`` when the run hit its fetch budget
+        or Metron's daily quota before reaching the end of the candidate list.
+    """
+    from models import metron
+
+    summary = {
+        "checked": 0,
+        "updated": 0,
+        "still_empty": 0,
+        "skipped": 0,
+        "errors": 0,
+        "stopped_early": False,
+        "dry_run": bool(dry_run),
+    }
+
+    api = metron.get_flask_api(app)
+    if not api:
+        app_logger.info("Credit backfill skipped: Metron API not configured")
+        summary["skipped_reason"] = "metron-unavailable"
+        return summary
+
+    scan_limit = min(MAX_SCAN, max(1, int(limit)) * SCAN_MULTIPLIER)
+    candidates = find_credit_less_files(days=days, limit=scan_limit)
+    if not candidates:
+        app_logger.info("Credit backfill: no credit-less files in the recent window")
+        return summary
+
+    app_logger.info(
+        f"Credit backfill: examining {len(candidates)} file(s) tagged in the last "
+        f"{days} days" + (" (dry run)" if dry_run else "")
+    )
+
+    for file_path in candidates:
+        # Only files we actually fetch for count against the budget; a file
+        # skipped without touching Metron costs nothing but a zip open.
+        fetched = summary["updated"] + summary["still_empty"] + summary["errors"]
+        if fetched >= limit:
+            summary["stopped_early"] = True
+            app_logger.info(f"Credit backfill stopped early: reached {limit} fetches")
+            break
+
+        # A spent daily quota makes every remaining fetch a no-op; stop rather
+        # than churn through hundreds of files that cannot succeed.
+        if metron._metron_pacer.daily_limit_reached():
+            summary["stopped_early"] = True
+            app_logger.info("Credit backfill stopped early: Metron daily limit reached")
+            break
+
+        summary["checked"] += 1
+        if on_progress is not None:
+            try:
+                on_progress(summary["checked"], len(candidates), os.path.basename(file_path))
+            except Exception:
+                pass
+        outcome = backfill_file(api, file_path, dry_run=dry_run)
+        if outcome == "updated":
+            summary["updated"] += 1
+        elif outcome == "still-empty":
+            summary["still_empty"] += 1
+        elif outcome == "error":
+            summary["errors"] += 1
+        else:
+            summary["skipped"] += 1
+
+    app_logger.info(
+        f"Credit backfill complete: {summary['checked']} checked, "
+        f"{summary['updated']} updated, {summary['still_empty']} still empty on "
+        f"Metron, {summary['skipped']} skipped, {summary['errors']} errors"
+        + (" (dry run)" if dry_run else "")
+    )
+    return summary

--- a/models/metron.py
+++ b/models/metron.py
@@ -277,6 +277,109 @@ def invalidate_session_cache() -> None:
     _metron_pacer.reset()
 
 
+def _purge_cached_keys(like_patterns, matches, context: str, api=None) -> int:
+    """Delete cached mokkari responses whose key satisfies ``matches``.
+
+    ``like_patterns`` narrows the scan in SQL; ``matches(key)`` decides, because
+    LIKE can't tell 8859 from 88591. Every duplicate row for a key goes:
+    ``store()`` is a plain INSERT and ``get()`` returns the first row, so one
+    leftover row keeps serving the stale body forever.
+
+    Args:
+        like_patterns: SQL LIKE patterns used to narrow the candidate rows.
+        matches: Predicate called with each candidate key; truthy means delete.
+        context: Human-readable subject, used only in log messages.
+        api: Optional Session to purge; defaults to every cached session.
+
+    Returns:
+        Number of cached rows removed.
+    """
+    if not like_patterns:
+        return 0
+
+    removed = 0
+    seen: List[Any] = []
+    where = " OR ".join(["key LIKE ?"] * len(like_patterns))
+    for session in [api] if api is not None else _cached_sessions():
+        cache = getattr(session, "cache", None)
+        con = getattr(cache, "con", None)
+        if con is None or any(cache is c for c in seen):
+            continue
+        seen.append(cache)
+        lock = getattr(cache, "_lock", None) or threading.Lock()
+        try:
+            with lock:
+                rows = con.execute(
+                    f"SELECT key FROM responses WHERE {where}",
+                    tuple(like_patterns),
+                ).fetchall()
+                keys = [row[0] for row in rows if matches(row[0])]
+                if keys:
+                    con.executemany(
+                        "DELETE FROM responses WHERE key = ?", [(k,) for k in keys]
+                    )
+                    con.commit()
+            removed += len(keys)
+        except Exception as e:
+            app_logger.warning(
+                f"Could not purge Metron response cache for {context}: {e}"
+            )
+    return removed
+
+
+def purge_issue_cache(issue_id, api=None) -> int:
+    """Drop mokkari's cached ``/issue/<id>/`` body so the next call re-fetches.
+
+    That response is the one carrying ``credits`` and ``characters``, and Metron
+    records are routinely completed *after* release day -- an issue tagged on
+    release morning can be indexed hours later. Because the cache has no working
+    expiry (see ``_metron_cache``), the incomplete body would otherwise be
+    replayed for the life of the process, so a re-tag would rewrite exactly the
+    metadata the user is trying to repair.
+
+    Args:
+        issue_id: Metron issue id whose cached detail response should be dropped.
+        api: Optional Session to purge; defaults to every cached session.
+
+    Returns:
+        Number of cached rows removed.
+    """
+    try:
+        issue_id = int(issue_id)
+    except (TypeError, ValueError):
+        return 0
+
+    # Anchored so 172615 can't take out 1726150 or ``?issue_id=172615``.
+    detail_re = re.compile(rf"/issue/{issue_id}/?(?:\?|$)")
+    removed = _purge_cached_keys(
+        [f"%/issue/{issue_id}%"], detail_re.search, f"issue {issue_id}", api=api
+    )
+    if removed:
+        app_logger.debug(
+            f"Purged {removed} cached Metron response(s) for issue {issue_id}"
+        )
+    return removed
+
+
+def _known_issue_ids(series_id) -> List[int]:
+    """Metron issue ids CLU has cached for a series; empty if the DB can't say."""
+    try:
+        from core.database import get_issues_for_series
+
+        rows = get_issues_for_series(series_id) or []
+    except Exception as e:
+        app_logger.debug(f"Could not list cached issues for series {series_id}: {e}")
+        return []
+
+    ids = []
+    for row in rows:
+        try:
+            ids.append(int(row["id"]))
+        except (TypeError, ValueError, KeyError, IndexError):
+            continue
+    return ids
+
+
 def purge_series_cache(series_id, api=None) -> int:
     """Drop mokkari's cached responses for one series so the next call re-fetches.
 
@@ -303,38 +406,21 @@ def purge_series_cache(series_id, api=None) -> int:
     # The series detail response, plus the paged issue lists filtered by it.
     detail_re = re.compile(rf"/series/{series_id}/?(?:\?|$)")
     issues_re = re.compile(rf"[?&]series_id={series_id}(?:&|$)")
+    removed = _purge_cached_keys(
+        [f"%/series/{series_id}%", f"%series_id={series_id}%"],
+        lambda key: detail_re.search(key) or issues_re.search(key),
+        f"series {series_id}",
+        api=api,
+    )
 
-    removed = 0
-    seen: List[Any] = []
-    for session in [api] if api is not None else _cached_sessions():
-        cache = getattr(session, "cache", None)
-        con = getattr(cache, "con", None)
-        if con is None or any(cache is c for c in seen):
-            continue
-        seen.append(cache)
-        lock = getattr(cache, "_lock", None) or threading.Lock()
-        try:
-            with lock:
-                rows = con.execute(
-                    "SELECT key FROM responses WHERE key LIKE ? OR key LIKE ?",
-                    (f"%/series/{series_id}%", f"%series_id={series_id}%"),
-                ).fetchall()
-                # LIKE can't tell 8859 from 88591; the regexes decide.
-                keys = [
-                    row[0]
-                    for row in rows
-                    if detail_re.search(row[0]) or issues_re.search(row[0])
-                ]
-                if keys:
-                    con.executemany(
-                        "DELETE FROM responses WHERE key = ?", [(k,) for k in keys]
-                    )
-                    con.commit()
-            removed += len(keys)
-        except Exception as e:
-            app_logger.warning(
-                f"Could not purge Metron response cache for series {series_id}: {e}"
-            )
+    # Those two only cover the series body and the issue *lists*. The per-issue
+    # detail bodies hold the credits, and their keys say nothing about the
+    # series -- ask CLU's own issue cache which ids belong to it. Guarded, so an
+    # uncached session never pays for the database round trip.
+    if any(getattr(s, "cache", None) is not None
+           for s in ([api] if api is not None else _cached_sessions())):
+        for issue_id in _known_issue_ids(series_id):
+            removed += purge_issue_cache(issue_id, api=api)
 
     if removed:
         app_logger.info(
@@ -716,6 +802,42 @@ def write_cvinfo_fields(
         return False
 
 
+def fetch_issue_detail(api, issue_id, context: str = ""):
+    """Fetch ``/issue/<id>/`` live, with any cached body dropped first.
+
+    The single entry point for fetching an issue *in order to write it into a
+    file*. Metadata written into an archive must never come from a cached body:
+    mokkari's cache has no working expiry (see ``_metron_cache``), and Metron
+    records are routinely completed hours after release day, so a body fetched
+    while the record was half-entered would be replayed for the life of the
+    process -- and a re-tag meant to repair the file would rewrite the very
+    metadata being repaired.
+
+    Display-only reads deliberately keep using the cache; only writes pay for a
+    live fetch, and within one job each issue is fetched once anyway.
+
+    Args:
+        api: Mokkari Session.
+        issue_id: Metron issue id.
+        context: Optional suffix for the rate-limit retry log messages.
+
+    Returns:
+        The mokkari ``Issue`` object, or None when the call failed.
+    """
+    try:
+        issue_id = int(issue_id)
+    except (TypeError, ValueError):
+        return None
+
+    purge_issue_cache(issue_id, api=api)
+
+    def _fetch():
+        return api.issue(issue_id)
+
+    label = f"fetching details for issue ID {issue_id}"
+    return _api_call(_fetch, f"{label} {context}".strip())
+
+
 def get_issue_metadata(
     api, series_id: int, issue_number: str
 ) -> Optional[Dict[str, Any]]:
@@ -752,11 +874,10 @@ def get_issue_metadata(
         f"Found Metron issue ID {metron_issue_id}, fetching full details..."
     )
 
-    # Step 2: Fetch full details (separate retry scope)
-    def _fetch():
-        return _to_dict(api.issue(metron_issue_id))
-
-    result = _api_call(_fetch, f"fetching details for issue ID {metron_issue_id}")
+    # Step 2: Fetch full details (separate retry scope). Never from cache --
+    # this body is about to be written into a file; see fetch_issue_detail.
+    issue = fetch_issue_detail(api, metron_issue_id)
+    result = _to_dict(issue) if issue is not None else None
 
     if result and isinstance(result, dict):
         app_logger.debug(f"Metron data keys: {list(result.keys())}")

--- a/models/providers/metron_provider.py
+++ b/models/providers/metron_provider.py
@@ -245,13 +245,16 @@ class MetronProvider(BaseProvider):
     ) -> Dict[str, Any]:
         """Convert Metron issue data to ComicInfo.xml fields."""
         try:
-            # For full metadata, we need to fetch the complete issue data
+            # For full metadata, we need to fetch the complete issue data.
+            # fetch_issue_detail (not api.issue) because this body is written
+            # into an archive: it drops any cached copy first, so a bulk re-tag
+            # can't rewrite the same half-entered record it is meant to repair.
             api = self._get_api()
             if api and issue.id:
-                full_issue = api.issue(int(issue.id))
-                if full_issue:
-                    from models import metron as metron_module
+                from models import metron as metron_module
 
+                full_issue = metron_module.fetch_issue_detail(api, issue.id)
+                if full_issue:
                     return metron_module.map_to_comicinfo(full_issue)
 
             # Fallback: build from IssueResult

--- a/routes/metadata.py
+++ b/routes/metadata.py
@@ -25,6 +25,7 @@ from flask import (Blueprint, request, jsonify, Response,
 import core.app_state as app_state
 from core.app_logging import app_logger
 from core.config import config
+from core.auth import require_role
 from helpers.library import is_valid_library_path
 from models import gcd, metron, comicvine, comicvine_sqlite
 from models.gcd import STOPWORDS
@@ -3669,6 +3670,86 @@ def _rename_config_for(folder_path):
         "pattern": current_app.config.get("CUSTOM_RENAME_PATTERN", ""),
         "auto_rename": auto,
     }
+
+
+def _run_backfill_job(op_id, flask_app, days, limit, dry_run):
+    """Background worker for the manual credit backfill.
+
+    Metron's pacer allows ~15 requests a minute, so a full sweep runs for
+    minutes -- well past gunicorn's request timeout. It reports through
+    app_state instead, the same way the other long jobs do.
+    """
+    from core.credit_backfill import run_credit_backfill
+
+    try:
+        summary = run_credit_backfill(
+            days=days,
+            limit=limit,
+            dry_run=dry_run,
+            app=flask_app,
+            on_progress=lambda current, total, name: app_state.update_operation(
+                op_id, current=current, total=total, detail=name
+            ),
+        )
+        app_state.update_operation(
+            op_id,
+            detail=f"{summary['updated']} of {summary['checked']} file(s) updated",
+        )
+        app_state.complete_operation(op_id)
+        return summary
+    except Exception as e:
+        app_logger.error(f"[backfill-credits] Sweep failed: {e}")
+        app_state.complete_operation(op_id, error=True)
+        return None
+
+
+@metadata_bp.route('/api/metadata/backfill-credits', methods=['POST'])
+@require_role("owner")
+def backfill_credits():
+    """Re-fetch Metron credits for recently tagged files that have none.
+
+    Metron records are often completed after a comic ships, so a file tagged on
+    release morning can be written with no creators at all -- and once ComicInfo
+    carries Notes, no automatic path ever re-tags it. This is the manual trigger
+    for the same sweep the daily series sync runs (core.credit_backfill), for
+    when the user wants those files repaired now.
+
+    Input: {days, limit, dry_run} -- all optional.
+    Returns an op_id immediately; progress lands in Active Operations.
+    """
+    from core.credit_backfill import DEFAULT_DAYS, DEFAULT_LIMIT
+
+    try:
+        data = request.get_json(silent=True) or {}
+
+        try:
+            days = int(data.get('days', DEFAULT_DAYS))
+            limit = int(data.get('limit', DEFAULT_LIMIT))
+        except (TypeError, ValueError):
+            return jsonify({"success": False, "error": "days and limit must be numbers"}), 400
+        if days < 1 or limit < 1:
+            return jsonify({"success": False, "error": "days and limit must be positive"}), 400
+
+        dry_run = bool(data.get('dry_run'))
+        op_id = app_state.register_operation(
+            "credit_backfill", "Backfilling creator credits"
+        )
+        # An explicit request runs regardless of the credit_backfill_enabled
+        # preference -- that switch only governs the scheduled sweep.
+        threading.Thread(
+            target=_run_backfill_job,
+            args=(op_id, current_app._get_current_object(), days, limit, dry_run),
+            daemon=True,
+        ).start()
+
+        return jsonify({
+            "success": True,
+            "op_id": op_id,
+            "message": "Credit backfill started — progress shows in Active Operations",
+        }), 202
+    except Exception as e:
+        app_logger.error(f"[backfill-credits] Error: {e}")
+        return jsonify({"success": False, "error": str(e)}), 500
 
 
 @metadata_bp.route('/api/provider-issues', methods=['POST'])

--- a/templates/base.html
+++ b/templates/base.html
@@ -196,7 +196,7 @@
             return b.started_at - a.started_at;
           });
 
-          const iconMap = { metadata: 'bi-tags', move: 'bi-arrows-move', convert: 'bi-arrow-repeat', rebuild: 'bi-hammer', import: 'bi-cloud-upload', upload: 'bi-cloud-arrow-up', match: 'bi-collection', repair: 'bi-wrench-adjustable', rename: 'bi-input-cursor-text' };
+          const iconMap = { metadata: 'bi-tags', move: 'bi-arrows-move', convert: 'bi-arrow-repeat', rebuild: 'bi-hammer', import: 'bi-cloud-upload', upload: 'bi-cloud-arrow-up', match: 'bi-collection', repair: 'bi-wrench-adjustable', rename: 'bi-input-cursor-text', credit_backfill: 'bi-person-badge' };
           let html = '';
           ops.forEach(op => {
             const icon = iconMap[op.op_type] || 'bi-gear';

--- a/templates/schedules.html
+++ b/templates/schedules.html
@@ -267,6 +267,29 @@
             </div>
         </div>
 
+        <div class="row mt-3 align-items-center">
+            <div class="col-md-8">
+                <div class="form-check form-switch">
+                    <input class="form-check-input" type="checkbox" id="creditBackfillEnabled" checked
+                        onchange="saveCreditBackfillPref()">
+                    <label class="form-check-label" for="creditBackfillEnabled">
+                        Backfill missing creator credits after each sync
+                    </label>
+                </div>
+                <small class="form-text text-muted">
+                    Metron often adds credits hours after a comic ships, so files tagged on release
+                    morning can end up with no creators. This re-checks recently tagged files and
+                    fills them in — existing tags are kept.
+                </small>
+            </div>
+            <div class="col-md-4">
+                <button type="button" class="btn btn-outline-primary w-100" onclick="runCreditBackfill()"
+                    title="Re-check recently tagged files for missing creator credits">
+                    <i class="bi bi-person-badge"></i> Backfill Credits Now
+                </button>
+            </div>
+        </div>
+
         <!-- GetComics Auto-Download Configuration -->
         <hr>
         <h5 class="mt-3 mb-3">GetComics Auto-Download Schedule</h5>
@@ -806,6 +829,73 @@
     }
 
     // =========================================
+    // Credit Backfill (missing creators)
+    // =========================================
+    function loadCreditBackfillPref() {
+        fetch('/api/preferences/credit_backfill_enabled')
+            .then(response => response.json())
+            .then(data => {
+                // An unset preference (null) means "on" — same as the server default.
+                const stored = data ? data.value : null;
+                document.getElementById('creditBackfillEnabled').checked = stored !== false;
+            })
+            .catch(error => console.error('Error loading credit backfill preference:', error));
+    }
+
+    function saveCreditBackfillPref() {
+        const enabled = document.getElementById('creditBackfillEnabled').checked;
+        fetch('/api/preferences/credit_backfill_enabled', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ value: enabled, category: 'metadata' })
+        })
+            .then(response => response.json())
+            .then(data => {
+                if (data.success) {
+                    showToast(enabled ? 'Credit backfill enabled' : 'Credit backfill disabled', 'success');
+                } else {
+                    showToast(data.error || 'Could not save preference', 'error');
+                }
+            })
+            .catch(error => {
+                console.error('Error saving credit backfill preference:', error);
+                showToast('Network error occurred', 'error');
+            });
+    }
+
+    function runCreditBackfill() {
+        const button = event.target.closest('button');
+        const originalText = button.innerHTML;
+
+        button.innerHTML = '<i class="bi bi-arrow-repeat spin"></i> Starting...';
+        button.disabled = true;
+
+        // The sweep is paced by Metron's rate limiter and runs for minutes, so
+        // the server hands back an op id and reports through Active Operations.
+        fetch('/api/metadata/backfill-credits', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({})
+        })
+            .then(response => response.json())
+            .then(data => {
+                if (data.success) {
+                    showToast(data.message || 'Credit backfill started', 'success');
+                } else {
+                    showToast(data.error || 'Unknown error', 'error');
+                }
+            })
+            .catch(error => {
+                console.error('Error running credit backfill:', error);
+                showToast('Network error occurred', 'error');
+            })
+            .finally(() => {
+                button.innerHTML = originalText;
+                button.disabled = false;
+            });
+    }
+
+    // =========================================
     // GetComics Schedule Functions
     // =========================================
     function loadGetcomicsSchedule() {
@@ -1034,6 +1124,7 @@
         loadSyncSchedule();
         loadGetcomicsSchedule();
         loadRlSyncSchedule();
+        loadCreditBackfillPref();
     });
 </script>
 {% endblock %}

--- a/tests/mocked/test_metron_model.py
+++ b/tests/mocked/test_metron_model.py
@@ -229,6 +229,147 @@ class TestPurgeSeriesCache:
         invalidate_session_cache()
 
 
+class TestPurgeIssueCache:
+    """The ``/issue/<id>/`` body is the one carrying credits.
+
+    Metron records are finished after a comic ships, so an issue fetched on
+    release morning can be cached without creators. ``purge_series_cache``
+    never touched these keys, which made every re-tag replay the incomplete
+    body for the life of the process.
+    """
+
+    ISSUE_URL = "https://metron.cloud/api/issue/172615/"
+
+    def _session_with_cache(self, tmp_path):
+        from mokkari.sqlite_cache import SqliteCache
+
+        cache = SqliteCache(db_name=str(tmp_path / "mokkari_cache.db"), expire=1)
+        return SimpleNamespace(cache=cache), cache
+
+    def test_drops_the_issue_detail_row(self, tmp_path):
+        from models.metron import purge_issue_cache
+
+        session, cache = self._session_with_cache(tmp_path)
+        cache.store(self.ISSUE_URL, {"credits": []})
+
+        assert purge_issue_cache(172615, api=session) == 1
+        assert cache.get(self.ISSUE_URL) is None
+
+    def test_leaves_other_issues_alone(self, tmp_path):
+        """LIKE '%/issue/172615%' also matches 1726150 and ?issue_id=172615."""
+        from models.metron import purge_issue_cache
+
+        session, cache = self._session_with_cache(tmp_path)
+        other_issue = "https://metron.cloud/api/issue/1726150/"
+        filtered = "https://metron.cloud/api/credit/?issue_id=172615"
+        cache.store(self.ISSUE_URL, {"credits": []})
+        cache.store(other_issue, {"credits": ["someone"]})
+        cache.store(filtered, {"results": []})
+
+        assert purge_issue_cache(172615, api=session) == 1
+        assert cache.get(other_issue) == {"credits": ["someone"]}
+        assert cache.get(filtered) == {"results": []}
+
+    def test_drops_every_duplicate_row_for_a_key(self, tmp_path):
+        """store() appends, so one leftover row keeps serving the stale body."""
+        from models.metron import purge_issue_cache
+
+        session, cache = self._session_with_cache(tmp_path)
+        cache.store(self.ISSUE_URL, {"credits": []})
+        cache.store(self.ISSUE_URL, {"credits": []})
+
+        assert purge_issue_cache(172615, api=session) == 2
+        assert cache.get(self.ISSUE_URL) is None
+
+    def test_session_without_a_cache_is_a_no_op(self):
+        from models.metron import purge_issue_cache
+
+        assert purge_issue_cache(172615, api=SimpleNamespace(cache=None)) == 0
+
+    def test_non_numeric_issue_id_is_a_no_op(self, tmp_path):
+        from models.metron import purge_issue_cache
+
+        session, cache = self._session_with_cache(tmp_path)
+        cache.store(self.ISSUE_URL, {"credits": []})
+
+        assert purge_issue_cache("not-an-id", api=session) == 0
+        assert cache.get(self.ISSUE_URL) == {"credits": []}
+
+    def test_series_purge_also_drops_known_issue_details(self, tmp_path):
+        """A series refresh has to clear the issue bodies too, or the summary
+        refreshes while every issue keeps its stale credits."""
+        from models.metron import purge_series_cache
+
+        session, cache = self._session_with_cache(tmp_path)
+        cache.store("https://metron.cloud/api/series/8859/", {"desc": "old"})
+        cache.store(self.ISSUE_URL, {"credits": []})
+
+        with patch(
+            "core.database.get_issues_for_series",
+            return_value=[{"id": 172615}, {"id": 999999}],
+        ):
+            assert purge_series_cache(8859, api=session) == 2
+
+        assert cache.get(self.ISSUE_URL) is None
+
+    def test_series_purge_survives_a_database_failure(self, tmp_path):
+        from models.metron import purge_series_cache
+
+        session, cache = self._session_with_cache(tmp_path)
+        cache.store("https://metron.cloud/api/series/8859/", {"desc": "old"})
+
+        with patch("core.database.get_issues_for_series", side_effect=RuntimeError("db down")):
+            assert purge_series_cache(8859, api=session) == 1
+
+
+class TestFetchIssueDetail:
+    """Metadata written into an archive must never come from a cached body."""
+
+    ISSUE_URL = "https://metron.cloud/api/issue/172615/"
+
+    def _session_with_cache(self, tmp_path):
+        from mokkari.sqlite_cache import SqliteCache
+
+        cache = SqliteCache(db_name=str(tmp_path / "mokkari_cache.db"), expire=1)
+        api = MagicMock()
+        api.cache = cache
+        return api, cache
+
+    def test_drops_the_cached_body_before_fetching(self, tmp_path):
+        from models.metron import fetch_issue_detail
+
+        api, cache = self._session_with_cache(tmp_path)
+        cache.store(self.ISSUE_URL, {"credits": []})
+        api.issue.return_value = SimpleNamespace(id=172615)
+
+        result = fetch_issue_detail(api, 172615)
+
+        assert cache.get(self.ISSUE_URL) is None
+        api.issue.assert_called_once_with(172615)
+        assert result.id == 172615
+
+    def test_non_numeric_id_never_calls_the_api(self, tmp_path):
+        from models.metron import fetch_issue_detail
+
+        api, _ = self._session_with_cache(tmp_path)
+        assert fetch_issue_detail(api, "not-an-id") is None
+        api.issue.assert_not_called()
+
+    def test_get_issue_metadata_uses_the_purging_fetch(self, tmp_path):
+        """The double fetch's second call is the one written to disk."""
+        from models.metron import get_issue_metadata
+
+        api, cache = self._session_with_cache(tmp_path)
+        cache.store(self.ISSUE_URL, {"credits": [], "number": "3"})
+        api.issues_list.return_value = [SimpleNamespace(id=172615)]
+        api.issue.return_value = {"number": "3", "credits": [{"creator": "Bengal"}]}
+
+        result = get_issue_metadata(api, 15845, "3")
+
+        assert cache.get(self.ISSUE_URL) is None
+        assert result["credits"] == [{"creator": "Bengal"}]
+
+
 class TestIsConnectionError:
 
     def test_timeout_detected(self):

--- a/tests/mocked/test_metron_provider.py
+++ b/tests/mocked/test_metron_provider.py
@@ -230,6 +230,39 @@ class TestMetronProviderToComicinfo:
         assert result["Series"] == "Batman"
         assert result["Publisher"] == "DC Comics"
 
+    @patch("models.metron.get_api")
+    @patch("models.metron.map_to_comicinfo")
+    def test_fetches_through_the_cache_purging_helper(self, mock_map, mock_get_api,
+                                                      metron_creds, tmp_path):
+        """This body is written into an archive, so it must not come from cache.
+
+        to_comicinfo backs the bulk re-tag. Calling api.issue() directly would
+        replay whatever Metron returned the first time this process asked --
+        i.e. the very half-entered record the re-tag is meant to repair.
+        """
+        from mokkari.sqlite_cache import SqliteCache
+        from models.providers.metron_provider import MetronProvider
+
+        cache = SqliteCache(db_name=str(tmp_path / "mokkari_cache.db"), expire=1)
+        cache.store("https://metron.cloud/api/issue/500/", {"credits": []})
+
+        mock_api = MagicMock()
+        mock_api.cache = cache
+        mock_api.issue.return_value = make_mock_issue()
+        mock_get_api.return_value = mock_api
+        mock_map.return_value = {"Series": "Batman", "Writer": "Joe Kelly"}
+
+        p = MetronProvider(credentials=metron_creds)
+        issue = IssueResult(
+            provider=ProviderType.METRON, id="500", series_id="100",
+            issue_number="1", title="Test",
+        )
+
+        result = p.to_comicinfo(issue)
+
+        assert cache.get("https://metron.cloud/api/issue/500/") is None
+        assert result["Writer"] == "Joe Kelly"
+
     def test_fallback_without_api(self):
         from models.providers.metron_provider import MetronProvider
 

--- a/tests/routes/test_metadata_routes.py
+++ b/tests/routes/test_metadata_routes.py
@@ -1776,3 +1776,89 @@ class TestDateCheckFallthrough:
 
         single = inspect.getsource(metadata_module.search_metadata)
         assert "_issue_date_of(metadata, provider_type)" in single
+
+
+class TestBackfillCredits:
+    """Manual trigger for the Metron credit backfill sweep.
+
+    Metron finishes issue records after a comic ships, so files tagged on
+    release morning can be written with no creators -- and nothing re-tags a
+    file that already has Notes. This route is how a user repairs them now
+    instead of waiting for the nightly series sync.
+    """
+
+    @patch("routes.metadata.threading.Thread")
+    def test_starts_in_the_background_and_returns_an_op_id(self, mock_thread, client):
+        """A full sweep runs for minutes (Metron pacing), so the request must
+        not wait on it -- gunicorn's timeout is 120s."""
+        resp = client.post('/api/metadata/backfill-credits', json={})
+
+        assert resp.status_code == 202
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["op_id"]
+        mock_thread.return_value.start.assert_called_once()
+
+    @patch("routes.metadata.threading.Thread")
+    def test_passes_window_and_dry_run_to_the_worker(self, mock_thread, client):
+        resp = client.post('/api/metadata/backfill-credits',
+                           json={"days": 7, "limit": 5, "dry_run": True})
+
+        assert resp.status_code == 202
+        _op_id, _app, days, limit, dry_run = mock_thread.call_args.kwargs["args"]
+        assert (days, limit, dry_run) == (7, 5, True)
+
+    @patch("routes.metadata.threading.Thread")
+    def test_defaults_when_no_body(self, mock_thread, client):
+        from core.credit_backfill import DEFAULT_DAYS, DEFAULT_LIMIT
+
+        resp = client.post('/api/metadata/backfill-credits')
+
+        assert resp.status_code == 202
+        _op_id, _app, days, limit, _dry = mock_thread.call_args.kwargs["args"]
+        assert (days, limit) == (DEFAULT_DAYS, DEFAULT_LIMIT)
+
+    @patch("routes.metadata.threading.Thread")
+    def test_rejects_a_nonsense_window(self, mock_thread, client):
+        resp = client.post('/api/metadata/backfill-credits', json={"days": 0})
+
+        assert resp.status_code == 400
+        assert resp.get_json()["success"] is False
+        mock_thread.assert_not_called()
+
+    @patch("routes.metadata.threading.Thread")
+    def test_rejects_non_numeric_window(self, mock_thread, client):
+        resp = client.post('/api/metadata/backfill-credits', json={"limit": "lots"})
+
+        assert resp.status_code == 400
+        mock_thread.assert_not_called()
+
+    @patch("core.credit_backfill.run_credit_backfill")
+    def test_worker_reports_the_summary_through_app_state(self, mock_run, app):
+        from routes.metadata import _run_backfill_job
+        import core.app_state as app_state
+
+        mock_run.return_value = {"checked": 3, "updated": 2, "still_empty": 1,
+                                 "skipped": 0, "errors": 0, "stopped_early": False,
+                                 "dry_run": False}
+        with app.test_request_context():
+            op_id = app_state.register_operation("credit_backfill", "test")
+        _run_backfill_job(op_id, app, 45, 200, False)
+
+        op = next(o for o in app_state.get_active_operations(is_owner=True)
+                  if o["id"] == op_id)
+        assert op["status"] == "completed"
+        assert "2 of 3" in op["detail"]
+
+    @patch("core.credit_backfill.run_credit_backfill", side_effect=RuntimeError("boom"))
+    def test_worker_failure_marks_the_operation_errored(self, mock_run, app):
+        from routes.metadata import _run_backfill_job
+        import core.app_state as app_state
+
+        with app.test_request_context():
+            op_id = app_state.register_operation("credit_backfill", "test")
+        assert _run_backfill_job(op_id, app, 45, 200, False) is None
+
+        op = next(o for o in app_state.get_active_operations(is_owner=True)
+                  if o["id"] == op_id)
+        assert op["status"] == "error"

--- a/tests/unit/test_credit_backfill.py
+++ b/tests/unit/test_credit_backfill.py
@@ -1,0 +1,290 @@
+"""Unit tests for the Metron credit backfill sweep.
+
+Metron records are routinely completed after a comic ships, so a file tagged on
+release morning can carry a valid ComicInfo.xml with no creators at all -- and
+once ComicInfo has Notes, every automatic tagging path skips the file forever.
+These cover the sweep that repairs those files, and the two rules that keep it
+from churning: it only rewrites when Metron actually has credits now, and it
+never touches a file it can't identify.
+"""
+import os
+import zipfile
+from unittest.mock import patch
+
+import pytest
+
+from core.comicinfo import read_comicinfo_from_zip
+from core.credit_backfill import _has_credits, backfill_file, run_credit_backfill
+
+
+CREDIT_LESS_XML = b"""<?xml version='1.0' encoding='utf-8'?>
+<ComicInfo>
+  <Series>Absolute Catwoman</Series>
+  <Number>3</Number>
+  <Genre>Super-Hero</Genre>
+  <Characters>Catwoman (Earth Alpha)</Characters>
+  <MetronId>172615</MetronId>
+  <Notes>Metadata from Metron. Resource URL: https://metron.cloud/issue/absolute-catwoman-2026-3/ - modified 2026-08-26T06:20:00.</Notes>
+</ComicInfo>
+"""
+
+CREDITED_METADATA = {
+    "Series": "Absolute Catwoman",
+    "Number": "3",
+    "Writer": "Che Grayson, Scott Snyder",
+    "Penciller": "Bengal",
+    "Colorist": "Giovanna Niro",
+    "Letterer": "Lucas Gattoni",
+    "MetronId": 172615,
+    "Notes": "Metadata from Metron. Resource URL: https://metron.cloud/issue/absolute-catwoman-2026-3/ - modified 2026-08-26T08:35:11.",
+}
+
+
+def _make_cbz(tmp_path, name="Absolute Catwoman 003 (2026).cbz", xml=CREDIT_LESS_XML):
+    path = os.path.join(str(tmp_path), name)
+    with zipfile.ZipFile(path, "w") as z:
+        z.writestr("001.jpg", b"not-really-an-image")
+        if xml is not None:
+            z.writestr("ComicInfo.xml", xml)
+    return path
+
+
+@pytest.fixture
+def no_index_write():
+    """The sweep updates file_index after a rewrite; unit tests have no DB."""
+    with patch("core.database.update_file_index_from_comicinfo", return_value=True):
+        yield
+
+
+class TestHasCredits:
+
+    def test_any_credit_counts(self):
+        assert _has_credits({"CoverArtist": "Eric Canete"}) is True
+
+    def test_blank_and_missing_do_not(self):
+        assert _has_credits({"Writer": "   ", "Penciller": None}) is False
+        assert _has_credits({}) is False
+
+    def test_editor_alone_is_not_a_credit(self):
+        """The Metron mapper never emits Editor, so it can't prove completeness."""
+        assert _has_credits({"Editor": "Andrew Marino"}) is False
+
+
+class TestBackfillFile:
+
+    def test_adds_credits_and_keeps_existing_tags(self, tmp_path, no_index_write):
+        path = _make_cbz(tmp_path)
+
+        with patch("models.metron.fetch_issue_detail", return_value={"id": 172615}), \
+             patch("models.metron.map_to_comicinfo", return_value=CREDITED_METADATA):
+            assert backfill_file(object(), path) == "updated"
+
+        result = read_comicinfo_from_zip(path)
+        assert result["Writer"] == "Che Grayson, Scott Snyder"
+        assert result["Penciller"] == "Bengal"
+        # merge_existing: Metron supplied no Genre this time, and the sweep must
+        # add credits rather than replace what the file already had.
+        assert result["Genre"] == "Super-Hero"
+        # The images are still there -- the archive was rebuilt, not replaced.
+        with zipfile.ZipFile(path) as z:
+            assert "001.jpg" in z.namelist()
+
+    def test_fetches_by_the_metron_id_in_the_file(self, tmp_path, no_index_write):
+        path = _make_cbz(tmp_path)
+
+        with patch("models.metron.fetch_issue_detail", return_value={"id": 172615}) as fetch, \
+             patch("models.metron.map_to_comicinfo", return_value=CREDITED_METADATA):
+            backfill_file(object(), path)
+
+        assert fetch.call_args[0][1] == 172615
+
+    def test_still_empty_leaves_the_file_untouched(self, tmp_path, no_index_write):
+        """Metron still has no creators: don't rewrite, don't move the mtime."""
+        path = _make_cbz(tmp_path)
+        before = open(path, "rb").read()
+
+        with patch("models.metron.fetch_issue_detail", return_value={"id": 172615}), \
+             patch("models.metron.map_to_comicinfo", return_value={"Series": "Absolute Catwoman"}):
+            assert backfill_file(object(), path) == "still-empty"
+
+        assert open(path, "rb").read() == before
+
+    def test_dry_run_writes_nothing(self, tmp_path, no_index_write):
+        path = _make_cbz(tmp_path)
+        before = open(path, "rb").read()
+
+        with patch("models.metron.fetch_issue_detail", return_value={"id": 172615}), \
+             patch("models.metron.map_to_comicinfo", return_value=CREDITED_METADATA):
+            assert backfill_file(object(), path, dry_run=True) == "updated"
+
+        assert open(path, "rb").read() == before
+
+    def test_already_credited_file_is_skipped(self, tmp_path, no_index_write):
+        """The index row can be stale; the archive is the authority."""
+        xml = CREDIT_LESS_XML.replace(
+            b"<Number>3</Number>", b"<Number>3</Number>\n  <Writer>Che Grayson</Writer>"
+        )
+        path = _make_cbz(tmp_path, xml=xml)
+
+        with patch("models.metron.fetch_issue_detail") as fetch:
+            assert backfill_file(object(), path) == "skipped"
+        fetch.assert_not_called()
+
+    def test_non_metron_file_is_skipped(self, tmp_path, no_index_write):
+        xml = b"""<?xml version='1.0' encoding='utf-8'?>
+<ComicInfo>
+  <Series>Absolute Catwoman</Series>
+  <Number>3</Number>
+  <Notes>Metadata from ComicVine CVDB. [Issue ID 4000-1189465]</Notes>
+</ComicInfo>
+"""
+        path = _make_cbz(tmp_path, xml=xml)
+
+        with patch("models.metron.fetch_issue_detail") as fetch:
+            assert backfill_file(object(), path) == "skipped"
+        fetch.assert_not_called()
+
+    def test_file_without_comicinfo_is_skipped(self, tmp_path, no_index_write):
+        path = _make_cbz(tmp_path, xml=None)
+
+        with patch("models.metron.fetch_issue_detail") as fetch:
+            assert backfill_file(object(), path) == "skipped"
+        fetch.assert_not_called()
+
+    def test_missing_file_is_skipped(self, tmp_path):
+        assert backfill_file(object(), os.path.join(str(tmp_path), "gone.cbz")) == "skipped"
+
+    def test_failed_fetch_is_an_error_not_a_rewrite(self, tmp_path, no_index_write):
+        path = _make_cbz(tmp_path)
+        before = open(path, "rb").read()
+
+        with patch("models.metron.fetch_issue_detail", return_value=None):
+            assert backfill_file(object(), path) == "error"
+
+        assert open(path, "rb").read() == before
+
+    def test_old_file_without_metron_id_resolves_via_cvinfo(self, tmp_path, no_index_write):
+        """Files tagged before <MetronId> existed only carry the Notes line."""
+        xml = CREDIT_LESS_XML.replace(b"  <MetronId>172615</MetronId>\n", b"")
+        path = _make_cbz(tmp_path, xml=xml)
+        cvinfo = os.path.join(str(tmp_path), "cvinfo")
+        with open(cvinfo, "w", encoding="utf-8") as f:
+            f.write("https://comicvine.gamespot.com/absolute-catwoman/4050-165432/\nseries_id: 15845\n")
+
+        with patch("models.metron.get_issue_metadata", return_value={"id": 172615}) as lookup, \
+             patch("models.metron.fetch_issue_detail") as fetch, \
+             patch("models.metron.map_to_comicinfo", return_value=CREDITED_METADATA):
+            assert backfill_file(object(), path) == "updated"
+
+        assert lookup.call_args[0][1] == 15845
+        assert lookup.call_args[0][2] == "3"
+        # That lookup already fetched the issue live (get_issue_metadata purges
+        # the cached body itself), so re-fetching would only burn Metron quota.
+        fetch.assert_not_called()
+
+
+class TestRunCreditBackfill:
+
+    def test_no_metron_reports_and_stops(self):
+        with patch("models.metron.get_flask_api", return_value=None):
+            summary = run_credit_backfill()
+        assert summary["skipped_reason"] == "metron-unavailable"
+        assert summary["checked"] == 0
+
+    def test_counts_each_outcome(self, tmp_path):
+        paths = ["a.cbz", "b.cbz", "c.cbz", "d.cbz"]
+        outcomes = iter(["updated", "still-empty", "skipped", "error"])
+
+        with patch("models.metron.get_flask_api", return_value=object()), \
+             patch("core.credit_backfill.find_credit_less_files", return_value=paths), \
+             patch("core.credit_backfill.backfill_file", side_effect=lambda *a, **k: next(outcomes)):
+            summary = run_credit_backfill()
+
+        assert summary["checked"] == 4
+        assert summary["updated"] == 1
+        assert summary["still_empty"] == 1
+        assert summary["skipped"] == 1
+        assert summary["errors"] == 1
+        assert summary["stopped_early"] is False
+
+    def test_stops_when_the_daily_quota_is_spent(self):
+        """Every remaining fetch would be a no-op; don't churn through them."""
+        from models import metron
+
+        with patch("models.metron.get_flask_api", return_value=object()), \
+             patch("core.credit_backfill.find_credit_less_files", return_value=["a.cbz", "b.cbz"]), \
+             patch.object(metron._metron_pacer, "daily_limit_reached", return_value=True), \
+             patch("core.credit_backfill.backfill_file") as work:
+            summary = run_credit_backfill()
+
+        work.assert_not_called()
+        assert summary["stopped_early"] is True
+
+    def test_scans_wider_than_it_fetches(self):
+        """``limit`` caps Metron fetches, not files examined. Skips are nearly
+        free, and letting them fill the query's LIMIT would starve the files
+        that actually need a fetch."""
+        from core.credit_backfill import SCAN_MULTIPLIER
+
+        with patch("models.metron.get_flask_api", return_value=object()), \
+             patch("core.credit_backfill.find_credit_less_files", return_value=[]) as find:
+            run_credit_backfill(days=7, limit=25)
+
+        assert find.call_args.kwargs == {"days": 7, "limit": 25 * SCAN_MULTIPLIER}
+
+    def test_skips_do_not_consume_the_fetch_budget(self):
+        paths = [f"{i}.cbz" for i in range(10)]
+
+        with patch("models.metron.get_flask_api", return_value=object()), \
+             patch("core.credit_backfill.find_credit_less_files", return_value=paths), \
+             patch("core.credit_backfill.backfill_file", return_value="skipped"):
+            summary = run_credit_backfill(limit=2)
+
+        assert summary["checked"] == 10
+        assert summary["stopped_early"] is False
+
+    def test_stops_once_the_fetch_budget_is_spent(self):
+        paths = [f"{i}.cbz" for i in range(10)]
+
+        with patch("models.metron.get_flask_api", return_value=object()), \
+             patch("core.credit_backfill.find_credit_less_files", return_value=paths), \
+             patch("core.credit_backfill.backfill_file", return_value="updated"):
+            summary = run_credit_backfill(limit=2)
+
+        assert summary["updated"] == 2
+        assert summary["stopped_early"] is True
+
+
+class TestFindCreditLessFiles:
+
+    def test_query_window_and_limit(self):
+        """Recency uses mtime, not metadata_scanned_at: the scanner refreshes
+        the latter, which would keep a file in the window forever."""
+        from core.credit_backfill import find_credit_less_files
+
+        captured = {}
+
+        class _Conn:
+            def execute(self, sql, params):
+                captured["sql"] = sql
+                captured["params"] = params
+                return self
+
+            def fetchall(self):
+                return [("/data/DC/a.cbz",)]
+
+            def close(self):
+                pass
+
+        with patch("core.database.get_db_connection", return_value=_Conn()):
+            assert find_credit_less_files(days=10, limit=5) == ["/data/DC/a.cbz"]
+
+        assert "modified_at >= ?" in captured["sql"]
+        assert "ci_writer" in captured["sql"] and "ci_coverartist" in captured["sql"]
+        assert captured["params"][1] == 5
+
+    def test_database_failure_returns_nothing(self):
+        from core.credit_backfill import find_credit_less_files
+
+        with patch("core.database.get_db_connection", return_value=None):
+            assert find_credit_less_files() == []

--- a/tests/unit/test_credit_backfill_hook.py
+++ b/tests/unit/test_credit_backfill_hook.py
@@ -1,0 +1,93 @@
+"""The credit-backfill hook in app.scheduled_series_sync.
+
+The sweep rides the nightly Metron sync rather than owning a schedule, so two
+properties matter and neither is observable by calling the function: it must be
+gated on the ``credit_backfill_enabled`` preference, and it must sit inside its
+own try/except so a backfill problem can never take the series sync down with
+it. Both are asserted against the parsed AST -- app.py cannot be imported in
+tests (it starts the scheduler and spawns monitor.py at import).
+
+The sweep's own behaviour is covered in tests/unit/test_credit_backfill.py.
+"""
+
+import ast
+import os
+
+import pytest
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+APP_PATH = os.path.join(PROJECT_ROOT, "app.py")
+
+FUNC = "scheduled_series_sync"
+
+
+@pytest.fixture(scope="module")
+def func_node():
+    with open(APP_PATH, encoding="utf-8") as fh:
+        tree = ast.parse(fh.read())
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == FUNC:
+            return node
+    pytest.fail(f"{FUNC} not found in app.py")
+
+
+def _backfill_calls(node):
+    return [
+        child for child in ast.walk(node)
+        if isinstance(child, ast.Call)
+        and isinstance(child.func, ast.Name)
+        and child.func.id == "run_credit_backfill"
+    ]
+
+
+def test_sync_runs_the_backfill_exactly_once(func_node):
+    assert len(_backfill_calls(func_node)) == 1
+
+
+def test_backfill_is_gated_on_the_preference(func_node):
+    """Users who don't want their archives rewritten in the background can say
+    so; without the gate the switch would be decorative."""
+    gated = False
+    for stmt in ast.walk(func_node):
+        if not isinstance(stmt, ast.If):
+            continue
+        test_src = ast.dump(stmt.test)
+        if "credit_backfill_enabled" not in test_src:
+            continue
+        if any(_backfill_calls(body) for body in stmt.body):
+            gated = True
+    assert gated, "run_credit_backfill must sit inside the preference check"
+
+
+def test_backfill_failure_cannot_break_the_sync(func_node):
+    """The sync is the important job; the backfill is opportunistic repair."""
+    isolated = False
+    for stmt in ast.walk(func_node):
+        if not isinstance(stmt, ast.Try):
+            continue
+        if not any(_backfill_calls(body) for body in stmt.body):
+            continue
+        # The try that *contains* the call and nothing else of the sync's work.
+        if len(stmt.handlers) >= 1:
+            isolated = True
+    assert isolated, "run_credit_backfill must be wrapped in its own try/except"
+
+
+def test_backfill_runs_after_the_sync_finishes(func_node):
+    """Credits for issues imported by this very run are worth picking up, and a
+    sweep that ran first would also compete with the sync for Metron's quota."""
+    outer = next((stmt for stmt in func_node.body if isinstance(stmt, ast.Try)), None)
+    assert outer is not None, (
+        "scheduled_series_sync is expected to wrap its work in a try block"
+    )
+    statements = outer.body
+    backfill_index = next(
+        (i for i, stmt in enumerate(statements) if _backfill_calls(stmt)), None
+    )
+    assert backfill_index is not None
+    # Everything that fetches series from Metron comes before it.
+    loop_index = max(
+        (i for i, stmt in enumerate(statements) if isinstance(stmt, ast.For)),
+        default=-1,
+    )
+    assert loop_index != -1 and backfill_index > loop_index


### PR DESCRIPTION
Comics tagged on release morning came out with no creator credits at all — reported by several users. Two files from the same sweep, five seconds apart:

| File | mtime | Credits |
|---|---|---|
| `The Amazing Spider-Man 035 (2026).cbz` | 06:31:03 | present |
| `Absolute Catwoman 003 (2026).cbz` | 06:30:58 | **missing** |

Both name Metron in `<Notes>`, and Metron's API returns full credits for both issues.

## What was actually wrong

The mapper was never at fault — both payloads produce credits through `map_to_comicinfo`. The body CLU saw simply was not the body the API returns now, for two reasons that compound:

1. **mokkari's response cache has no working TTL.** `SqliteCache.get()` never checks the `expire` column and `cleanup()` runs only in `__init__`, so on a long-lived container the effective TTL is process uptime. `store()` is a plain INSERT and `get()` returns the first row, so a fresh fetch can never displace a stale one — it has to be deleted.
2. **Metron finishes issue records after a comic ships.** `Absolute Catwoman #3` was still being edited two hours after the file was written.

Either way the file was stuck. Once ComicInfo carries `Notes`, every automatic tagging path skips it forever — and a manual re-tag was a no-op, because `purge_series_cache` only dropped `/series/<id>` and `?series_id=` keys, never `/issue/<id>/`, which is the response that carries `credits`.

## Changes

**Cache correctness** (`models/metron.py`)

- `purge_issue_cache()` — drops the cached `/issue/<id>/` rows, anchored so `172615` can't take out `1726150` or `?issue_id=172615`, and removes every duplicate row for the key.
- `fetch_issue_detail()` — the single entry point for fetching an issue *in order to write it into a file*: purges the cached body, then fetches through `_api_call`. Wired into `get_issue_metadata`'s second fetch and into `MetronProvider.to_comicinfo` — the one the bulk re-tag uses, so without it `overwrite_existing` rewrote the same half-entered record it was meant to repair. That call site also gains the rate-limit retry it never had.
- `purge_series_cache()` now also drops the issue-detail bodies for the series' known issues, so the series page's "Refresh from Metron" means what it says.
- Display-only reads (`get_issue`, `issue_view`) and `issues_list` searches keep using the cache — ids are stable and those lists are the bulk of the quota.

**Recovery sweep** (new `core/credit_backfill.py`)

- Finds credit-less files with one `file_index` query — no archive I/O to select them.
- Re-fetches each issue live, and **rewrites only when Metron now actually has credits**, merging so tags the file already carries survive.
- Recency is keyed on **mtime**, not `metadata_scanned_at` (the scanner refreshes the latter, which would keep a file in the window forever). A comic Metron will never have credits for ages out of the 45-day window instead of being re-fetched nightly.
- `limit` caps Metron *fetches*, not files examined — skips are nearly free, and letting them fill the query's LIMIT would starve the files that need a fetch.
- Stops early on the fetch budget or a spent daily quota.

**Wiring**

- Runs after each series sync, behind a `credit_backfill_enabled` preference and its own `try/except` so a backfill problem can never fail the sync.
- `POST /api/metadata/backfill-credits` (owner-only) for on-demand repair — backgrounded with a tracked operation, since a full sweep is paced at ~15 requests/min and would outlast gunicorn's 120s timeout.
- Toggle and "Backfill Credits Now" button on the Schedules page; progress shows in Active Operations.

## Tests

`pytest`: **4216 passed, 7 skipped** (the usual POSIX/symlink skips on Windows).

- `tests/unit/test_credit_backfill.py` — real CBZ fixtures: credits added with `<Genre>` preserved by the merge; a still-credit-less payload leaves the file byte-identical; already-credited and non-Metron files skipped without an API call; skips don't consume the fetch budget; dry run writes nothing.
- `tests/unit/test_credit_backfill_hook.py` — AST assertions that the sync hook is gated on the preference, isolated in its own `try/except`, and runs after the sync loop (app.py can't be imported in tests).
- `tests/mocked/test_metron_model.py` — purge precision, duplicate rows, uncached sessions, and that `get_issue_metadata` deletes a pre-seeded stale row before fetching.
- `tests/mocked/test_metron_provider.py` — `to_comicinfo` fetches through the purging helper.
- `tests/routes/test_metadata_routes.py` — the new route: backgrounded with an op id, argument validation, and worker success/failure reporting.

## Verifying against a live instance

```bash
# the stale row, before and after
sqlite3 $CACHE_DIR/providers/mokkari/mokkari_cache.db \
  "SELECT key, length(json) FROM responses WHERE key LIKE '%/issue/172615%';"

# blast radius
sqlite3 comic_utils.db "SELECT COUNT(*) FROM file_index WHERE type='file' AND has_comicinfo=1
  AND COALESCE(ci_writer,'')='' AND COALESCE(ci_penciller,'')=''
  AND COALESCE(ci_colorist,'')='' AND COALESCE(ci_letterer,'')=''
  AND COALESCE(ci_coverartist,'')='';"
```

Then Schedules → **Backfill Credits Now**, and `grep "Credit backfill" ` the log for the per-file and summary lines.

## Deliberately out of scope

- **ComicVine has the same shape of problem** — a day-of-release CV issue often has no `person_credits`, and the same "already has Notes" skip locks it in. The candidate query is provider-agnostic, so a CV arm can be added behind the same entry point.
- **Metron `Editor` credits are still never mapped.** `map_to_comicinfo` extracts Writer/Penciller/Inker/Colorist/Letterer/Cover but not Editor, even though the writer has emitted `<Editor>` since #515 and ComicVine/GCD both map it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
