### PR TITLE
Map Metron's editor credits into <Editor>

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -122,6 +122,7 @@ CLU is a comic metadata editor as well as a file tool. Metadata is written to `C
 - **Write from database** — push metadata already indexed in CLU back into the files.
 - **Creator credit backfill** — Metron often finishes an issue record hours after the comic ships, so a file tagged on release morning can land with no creators at all. CLU re-checks recently tagged files after each series sync (or on demand from Schedules) and fills the credits in, keeping the tags the file already has.
 - Provider-ID stripping from credits, and clickable Writer / Penciller / Character links in the issue info modal.
+- Editor credits from every provider, including Metron's spelled-out editorial roles (Assistant Editor, Group Editor, Editor In Chief).
 
 📖 [Metadata provider settings](https://clucomics.org/features/app-settings/metadata/) · [Source Wall](https://clucomics.org/features/collection/source-wall/) · [ComicInfo.xml options](https://clucomics.org/features/file-management/comicinfo/) · [Local databases](https://clucomics.org/features/local-databases/)
 

--- a/core/credit_backfill.py
+++ b/core/credit_backfill.py
@@ -30,9 +30,11 @@ from typing import Any, Dict, List, Optional
 from core.app_logging import app_logger
 
 # ComicInfo credit tags this sweep cares about, in ComicInfo and file_index
-# spellings. Editor/Translator are excluded on purpose: the Metron mapper does
-# not produce them, so their absence says nothing about whether a file is
-# missing credits.
+# spellings. Editor is excluded on purpose even though the Metron mapper now
+# fills it: a file carrying only an editor is still missing the creators, and
+# file_index has no ci_editor column to select on anyway. Files that already
+# have credits but predate the Editor mapping are left alone -- repairing those
+# is a re-tag, not a backfill.
 CREDIT_TAGS = ("Writer", "Penciller", "Inker", "Colorist", "Letterer", "CoverArtist")
 _CREDIT_COLUMNS = (
     "ci_writer",

--- a/models/metron.py
+++ b/models/metron.py
@@ -920,17 +920,27 @@ def _extract_names(items) -> Optional[str]:
     return ", ".join(names) if names else None
 
 
-def extract_credits_by_role(credits: List, role_names: List[str]) -> str:
+def extract_credits_by_role(
+    credits: List, role_names: List[str], substring: bool = False
+) -> str:
     """
     Extract creator names for specific roles from credits list.
 
     Args:
         credits: List of credit dicts or objects with 'creator' and 'role' fields
         role_names: List of role names to match (e.g., ['Writer'])
+        substring: Match when an entry in ``role_names`` appears *within* the
+            role name (case-insensitively) instead of equalling it. Metron
+            spells its editorial roles out in full -- "Editor In Chief",
+            "Executive Editor", "Assistant Editor" -- so an exact match would
+            collect almost none of them. This mirrors the ``editor`` needle in
+            ``models.comicvine._CV_ROLE_MATCHERS`` so both providers fill
+            <Editor> the same way.
 
     Returns:
         Comma-separated string of creator names
     """
+    needles = [n.lower() for n in role_names] if substring else None
     creators = []
     for credit in credits:
         roles = _get_attr(credit, "role", [])
@@ -940,10 +950,15 @@ def extract_credits_by_role(credits: List, role_names: List[str]) -> str:
             role_name = _get_attr(role, "name", "")
             if role_name is None:
                 role_name = str(role)
-            if role_name in role_names:
+            if substring:
+                matched = any(n in str(role_name).lower() for n in needles)
+            else:
+                matched = role_name in role_names
+            if matched:
                 creator_name = _get_attr(credit, "creator", "")
                 if creator_name and creator_name not in creators:
                     creators.append(creator_name)
+                break
     return ", ".join(creators)
 
 
@@ -1005,6 +1020,11 @@ def map_to_comicinfo(issue_data) -> Dict[str, Any]:
     colorist = extract_credits_by_role(credits, ["Colorist"])
     letterer = extract_credits_by_role(credits, ["Letterer"])
     cover_artist = extract_credits_by_role(credits, ["Cover"])
+    # Substring, because Metron names its editorial roles in full ("Editor In
+    # Chief", "Assistant Editor", "Group Editor"). Corporate titles that aren't
+    # editorial -- President, Publisher, Chief Creative Officer, Designer --
+    # don't contain the word and so stay out.
+    editor = extract_credits_by_role(credits, ["Editor"], substring=True)
 
     # Extract characters
     characters = _get_attr(issue_data, "characters", []) or []
@@ -1065,6 +1085,7 @@ def map_to_comicinfo(issue_data) -> Dict[str, Any]:
         "Colorist": colorist or None,
         "Letterer": letterer or None,
         "CoverArtist": cover_artist or None,
+        "Editor": editor or None,
         "Characters": characters_str,
         "Teams": teams_str,
         "Genre": genre_str,

--- a/tests/mocked/test_metron_model.py
+++ b/tests/mocked/test_metron_model.py
@@ -745,6 +745,82 @@ class TestExtractCreditsByRole:
         assert result["Writer"] == "Jeff Lemire"
 
 
+    def test_substring_matches_spelled_out_roles(self):
+        """Metron names editorial roles in full, so an exact match finds almost
+        none of them."""
+        from models.metron import extract_credits_by_role
+
+        credits = [
+            {"creator": "Nick Lowe", "role": [{"name": "Editor"}]},
+            {"creator": "Kaitlyn Lindtvedt", "role": [{"name": "Assistant Editor"}]},
+            {"creator": "C. B. Cebulski", "role": [{"name": "Editor In Chief"}]},
+        ]
+
+        assert extract_credits_by_role(credits, ["Editor"]) == "Nick Lowe"
+        assert extract_credits_by_role(credits, ["Editor"], substring=True) == (
+            "Nick Lowe, Kaitlyn Lindtvedt, C. B. Cebulski"
+        )
+
+    def test_substring_is_case_insensitive(self):
+        from models.metron import extract_credits_by_role
+
+        credits = [{"creator": "Nick Lowe", "role": [{"name": "SENIOR EDITOR"}]}]
+        assert extract_credits_by_role(credits, ["editor"], substring=True) == "Nick Lowe"
+
+    def test_a_creator_with_two_matching_roles_is_listed_once(self):
+        from models.metron import extract_credits_by_role
+
+        credits = [
+            {"creator": "Katie Kubert", "role": [{"name": "Editor"}, {"name": "Group Editor"}]},
+        ]
+        assert extract_credits_by_role(credits, ["Editor"], substring=True) == "Katie Kubert"
+
+    def test_editor_roles_land_in_the_editor_tag(self):
+        """<Editor> was in the writer's allowlist but the Metron mapper never
+        produced it, so every Metron-tagged file lost its editor credits."""
+        from models.metron import map_to_comicinfo
+
+        issue_data = {
+            "credits": [
+                {"creator": "Andrew Marino", "role": [{"name": "Editor"}]},
+                {"creator": "Chris Conroy", "role": [{"name": "Executive Editor"}]},
+                {"creator": "Katie Kubert", "role": [{"name": "Group Editor"}]},
+                {"creator": "Marie Javins", "role": [{"name": "Editor In Chief"}]},
+            ],
+        }
+        result = map_to_comicinfo(issue_data)
+        assert result["Editor"] == (
+            "Andrew Marino, Chris Conroy, Katie Kubert, Marie Javins"
+        )
+
+    def test_non_editorial_titles_stay_out_of_the_editor_tag(self):
+        """Metron credits a publisher's officers on the issue. None of those
+        titles contains "editor", which is what keeps them out."""
+        from models.metron import map_to_comicinfo
+
+        issue_data = {
+            "credits": [
+                {"creator": "Jim Lee", "role": [
+                    {"name": "President"},
+                    {"name": "Publisher"},
+                    {"name": "Chief Creative Officer"},
+                ]},
+                {"creator": "Jay Bowen", "role": [{"name": "Designer"}]},
+                {"creator": "Nick Lowe", "role": [{"name": "Editor"}]},
+            ],
+        }
+        result = map_to_comicinfo(issue_data)
+        assert result["Editor"] == "Nick Lowe"
+
+    def test_no_editor_credits_means_no_tag(self):
+        """The writer skips empty values, but None keeps it out of the dict the
+        UI and file_index read too."""
+        from models.metron import map_to_comicinfo
+
+        issue_data = {"credits": [{"creator": "Tom King", "role": [{"name": "Writer"}]}]}
+        assert "Editor" not in map_to_comicinfo(issue_data)
+
+
 class TestCalculateComicWeek:
 
     def test_returns_tuple(self):

--- a/tests/unit/test_credit_backfill.py
+++ b/tests/unit/test_credit_backfill.py
@@ -66,7 +66,8 @@ class TestHasCredits:
         assert _has_credits({}) is False
 
     def test_editor_alone_is_not_a_credit(self):
-        """The Metron mapper never emits Editor, so it can't prove completeness."""
+        """A file carrying only an editor is still missing its creators, so the
+        sweep must still treat it as a candidate."""
         assert _has_credits({"Editor": "Andrew Marino"}) is False
 
 


### PR DESCRIPTION
Follow-up to #520, which flagged this as out of scope.

`<Editor>` has been in the ComicInfo writer's allowlist since #515, and both ComicVine (`models/comicvine.py:993`) and GCD (`models/providers/gcd_api_provider.py:516`) fill it — but `models.metron.map_to_comicinfo` never extracted it. Every Metron-tagged file lost its editor credits silently.

## Why an exact role match wasn't enough

`extract_credits_by_role` compared role names for equality, which is right for `Writer` and `Colorist` but useless for editors: Metron spells the roles out in full. On the two issues from the original report, exact matching finds one name out of four each time.

`extract_credits_by_role` gains an opt-in `substring` mode, used only for Editor, mirroring the `editor` needle in `models.comicvine._CV_ROLE_MATCHERS` so both providers fill the tag the same way.

**Absolute Catwoman #3**
```xml
<Editor>Andrew Marino, Chris Conroy, Katie Kubert, Marie Javins</Editor>
```
| Creator | Metron role |
|---|---|
| Andrew Marino | Editor |
| Chris Conroy | Executive Editor |
| Katie Kubert | Group Editor |
| Marie Javins | Editor In Chief |

**The Amazing Spider-Man #35**
```xml
<Editor>C. B. Cebulski, Kaitlyn Lindtvedt, Nick Lowe, Tom Groneman</Editor>
```
| Creator | Metron role |
|---|---|
| C. B. Cebulski | Editor In Chief |
| Kaitlyn Lindtvedt | Assistant Editor |
| Nick Lowe | Editor |
| Tom Groneman | Associate Editor |

Non-editorial titles Metron credits on the issue — President, Publisher, Chief Creative Officer, Designer — don't contain the word, which is what keeps them out. That's asserted in a test rather than left to chance.

## Scope

- **New tagging only.** Editor lands on files tagged from here on, plus any file the #520 credit-less sweep repairs. Files that already have Writer/Penciller but no `<Editor>` are not rewritten — repairing those is a re-tag (bulk metadata with `overwrite_existing`), not a backfill.
- **Editor stays out of the backfill's credit-less test.** A file carrying only an editor is still missing its creators, so it must remain a candidate; `core/credit_backfill.py`'s stale comment about the mapper "not producing Editor" is corrected.

## Tests

`pytest`: **4222 passed, 7 skipped** (4216 on main plus the 6 added here).

New cases in `tests/mocked/test_metron_model.py`: substring vs exact on the same credit list, case-insensitivity, dedupe when one person holds two editorial roles, editorial roles reaching `<Editor>` through `map_to_comicinfo`, non-editorial titles staying out, and no tag emitted when there are no editor credits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
