### PR TITLE
Record the real mtime when a file is tagged

### DIFF
--- a/core/credit_backfill.py
+++ b/core/credit_backfill.py
@@ -15,10 +15,11 @@ where Metron now actually has credits.
 
 Two deliberate limits keep it cheap and self-terminating:
 
-* Candidates are restricted to files whose **mtime** is recent. mtime only moves
-  when the archive is rewritten, so a comic Metron will never have credits for
-  ages out of the window instead of being re-fetched every night.
-  ``metadata_scanned_at`` would be wrong here -- the scanner refreshes it.
+* Candidates are restricted to files whose **mtime** is recent. mtime is the
+  archive's last-write time -- writing ComicInfo rebuilds the file, so tagging
+  moves it, and ``update_file_index_from_comicinfo`` stamps the index row at that
+  moment. Nothing else does, so a comic Metron will never have credits for ages
+  out of the window instead of being re-fetched every night.
 * A file is rewritten only when the fresh payload really has credits, so a run
   that finds nothing new touches no bytes and no mtimes.
 """

--- a/core/database.py
+++ b/core/database.py
@@ -3937,7 +3937,8 @@ def update_file_index_from_comicinfo(file_path, comicinfo_dict):
     Update file_index name and ci_ columns from a ComicInfo-style metadata dict.
 
     Maps ComicInfo keys (Title, Series, Number, etc.) to ci_ database columns.
-    Also sets has_comicinfo=1 and metadata_scanned_at to the current time.
+    Also sets has_comicinfo=1, metadata_scanned_at to the current time, and
+    modified_at to the file's mtime (see below).
 
     Args:
         file_path: Path as stored in file_index (used for WHERE clause and name)
@@ -3983,6 +3984,23 @@ def update_file_index_from_comicinfo(file_path, comicinfo_dict):
         ci_characters = normalize_credit_list(comicinfo_dict.get("Characters", ""))
         scanned_at = time.time()
 
+        # Every caller reaches here immediately after rewriting the archive, and
+        # writing ComicInfo rebuilds the whole file (open_zip_for_write assembles
+        # a new archive and moves it into place), so the on-disk mtime has just
+        # jumped to now. Nothing else recorded that: the file_watcher misses
+        # events on the data mount and a directory sync may be days away, which
+        # left modified_at holding the file's *pre-tagging* mtime. A back issue
+        # re-tagged today then looked months old to everything keying on
+        # recency -- the credit backfill's window (core/credit_backfill.py) and
+        # the scanner's metadata_scanned_at < modified_at rescan trigger both
+        # read it. Callers pass the path as stored in file_index; when that
+        # can't be stat'ed, COALESCE below leaves the column as it was rather
+        # than guessing.
+        try:
+            file_mtime = os.path.getmtime(file_path)
+        except (OSError, ValueError):
+            file_mtime = None
+
         app_logger.info(
             f"update_file_index_from_comicinfo: series={ci_series}, "
             f"number={ci_number}, title={ci_title}, year={ci_year}, "
@@ -3997,7 +4015,8 @@ def update_file_index_from_comicinfo(file_path, comicinfo_dict):
                 ci_volume = ?, ci_year = ?, ci_writer = ?, ci_penciller = ?,
                 ci_inker = ?, ci_colorist = ?, ci_letterer = ?, ci_coverartist = ?,
                 ci_publisher = ?, ci_genre = ?, ci_characters = ?,
-                has_comicinfo = 1, metadata_scanned_at = ?
+                has_comicinfo = 1, metadata_scanned_at = ?,
+                modified_at = COALESCE(?, modified_at)
             WHERE path = ?
             """,
             (
@@ -4007,6 +4026,7 @@ def update_file_index_from_comicinfo(file_path, comicinfo_dict):
                 ci_inker, ci_colorist, ci_letterer, ci_coverartist,
                 ci_publisher, ci_genre, ci_characters,
                 scanned_at,
+                file_mtime,
                 file_path,
             ),
         )

--- a/tests/integration/test_database_file_index.py
+++ b/tests/integration/test_database_file_index.py
@@ -658,3 +658,61 @@ class TestFindFileIndexPathsByName:
             )
 
         assert len(find_file_index_paths_by_name("Dup.cbz", limit=2)) == 2
+
+
+class TestModifiedAtStampedOnTagging:
+    """Writing ComicInfo rebuilds the archive, so the file's mtime jumps to the
+    moment it was tagged. ``update_file_index_from_comicinfo`` is the funnel every
+    tagging path calls right after that rewrite, and it is the only thing that
+    records it -- the file_watcher misses events on the data mount. Without the
+    stamp the row keeps its pre-tagging mtime, and anything keying on recency
+    (the credit backfill's window, the scanner's rescan trigger) reads a file
+    tagged today as months old.
+    """
+
+    OLD = 1_600_000_000.0
+
+    def _modified_at(self, conn, path):
+        return conn.execute(
+            "SELECT modified_at FROM file_index WHERE path = ?", (path,)
+        ).fetchone()[0]
+
+    def test_stamps_the_files_current_mtime(self, db_connection, tmp_path):
+        import os
+        from core.database import (
+            add_file_index_entry,
+            update_file_index_from_comicinfo,
+        )
+
+        cbz = tmp_path / "Batman 001.cbz"
+        cbz.write_bytes(b"not-really-an-archive")
+        path = str(cbz)
+
+        add_file_index_entry(
+            "Batman 001.cbz", path, "file",
+            size=21, parent=str(tmp_path), modified_at=self.OLD,
+        )
+        assert self._modified_at(db_connection, path) == self.OLD
+
+        assert update_file_index_from_comicinfo(path, {"Series": "Batman"}) is True
+
+        assert self._modified_at(db_connection, path) == pytest.approx(
+            os.path.getmtime(path)
+        )
+
+    def test_unstattable_path_leaves_modified_at_alone(self, db_connection):
+        """Callers pass the path as stored in file_index, which does not always
+        resolve on the filesystem. Guessing a value would be worse than the
+        stale one, so the column is left untouched."""
+        from core.database import (
+            add_file_index_entry,
+            update_file_index_from_comicinfo,
+        )
+
+        path = "/data/DC/Nowhere 001.cbz"
+        add_file_index_entry(
+            "Nowhere 001.cbz", path, "file", parent="/data/DC", modified_at=self.OLD,
+        )
+
+        assert update_file_index_from_comicinfo(path, {"Series": "Nowhere"}) is True
+        assert self._modified_at(db_connection, path) == self.OLD

--- a/tests/unit/test_credit_backfill.py
+++ b/tests/unit/test_credit_backfill.py
@@ -259,8 +259,11 @@ class TestRunCreditBackfill:
 class TestFindCreditLessFiles:
 
     def test_query_window_and_limit(self):
-        """Recency uses mtime, not metadata_scanned_at: the scanner refreshes
-        the latter, which would keep a file in the window forever."""
+        """Recency uses mtime -- the archive's last-write time, stamped on the
+        index row by update_file_index_from_comicinfo when the file is tagged.
+        metadata_scanned_at would be wrong: a full rescan or the has_comicinfo
+        migration re-stamps it library-wide, dragging every old credit-less
+        comic into the window with nothing to age it back out."""
         from core.credit_backfill import find_credit_less_files
 
         captured = {}


### PR DESCRIPTION
Follow-up to #520. The credit backfill selects candidates on `file_index.modified_at`, on the stated reasoning that mtime is the archive's last-write time and therefore ages a comic out of the window on its own. The column is the right one — it is only ever written from `st_mtime` — but the value in it was not.

## What was wrong

Writing ComicInfo rebuilds the whole archive: `add_comicinfo_to_archive` → `open_zip_for_write` assembles a new file and `shutil.move`s it into place, with no `utime` restore. So the **on-disk** mtime jumps to the moment the file was tagged.

Nothing recorded that. `update_file_index_from_comicinfo` wrote the `ci_` columns, `has_comicinfo` and `metadata_scanned_at` and never touched `modified_at`; neither does the scanner's `update_file_metadata`. The only things that refresh it are the file_watcher — which misses events on the data mount — and a full directory sync.

The row therefore kept the file's *pre-tagging* mtime:

| Case | Index `modified_at` | Backfill sees it? |
|---|---|---|
| Downloaded, moved and tagged in one sweep | ≈ arrival time, seconds before the tag | yes |
| In the library for months, **re-tagged today** (bulk metadata run, "Refresh from Metron", the metadata search page) | months old | **no** |

The second row is the population the sweep exists to repair, and it was invisible to it. The scanner's `metadata_scanned_at < modified_at` rescan trigger and the collection view's "modified" column read the same stale value.

## Changes

`update_file_index_from_comicinfo` is the single funnel every tagging path calls immediately after the rewrite — `app.py` ×2, `routes/metadata.py` ×2, `core/bulk_metadata.py`, `core/credit_backfill.py` — so it now stamps the mtime it can see at that point. Callers pass the path as stored in `file_index`, which does not always resolve on disk; a failed stat leaves the column untouched via `COALESCE(?, modified_at)` rather than guessing.

**The backfill query is unchanged.** Widening it to also accept `metadata_scanned_at` was considered and rejected: the `has_comicinfo` migration NULLs that column library-wide and a full rescan re-stamps it, either of which would drag every old credit-less comic into the window and spend the nightly fetch budget on issues that will never gain credits — with nothing to age them back out.

Two comments (in `core/credit_backfill.py` and its test) claiming the scanner continuously refreshes `metadata_scanned_at` are corrected: a scan only runs when the file changed or `has_comicinfo != 1`.

## Tests

`pytest`: **4224 passed, 7 skipped** (the usual POSIX/symlink skips on Windows).

- `tests/integration/test_database_file_index.py` — a real file whose row carries a deliberately old `modified_at` is stamped with `os.path.getmtime` after tagging; a path with no file behind it keeps its existing value and still reports success.
- `tests/integration/test_credit_normalization.py` is the standing regression guard for that second case — it calls the function with `/data/C.cbz`, which does not exist.

## Verifying against a live instance

```bash
# before and after a re-tag from the metadata page
sqlite3 $CACHE_DIR/comic_utils.db \
  "SELECT modified_at, metadata_scanned_at FROM file_index WHERE path LIKE '%<file>%';"
stat -c %Y "<file>"    # modified_at should now match this, not the pre-tag value
```

Then re-tag a comic older than 45 days from a Metron record with no credits and `POST /api/metadata/backfill-credits` with `{"dry_run": true}` — it appears in `checked`, where before it was outside the window entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
