### PR TITLE
Drive the credit backfill from Metron's modified feed

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -120,7 +120,7 @@ CLU is a comic metadata editor as well as a file tool. Metadata is written to `C
 - **Create ComicInfo.xml when missing**, and a missing-XML view with rescan.
 - **Batch field updates** — set or clear specific ComicInfo fields across many files in parallel.
 - **Write from database** — push metadata already indexed in CLU back into the files.
-- **Creator credit backfill** — Metron often finishes an issue record hours after the comic ships, so a file tagged on release morning can land with no creators at all. CLU re-checks recently tagged files after each series sync (or on demand from Schedules) and fills the credits in, keeping the tags the file already has.
+- **Creator credit backfill** — Metron often finishes an issue record hours after the comic ships, so a file tagged on release morning can land with no creators at all. After each series sync (or on demand from Schedules) CLU asks Metron which issues have been edited since the last check, matches them against your library, and fills the credits in — keeping the tags the file already has. Files of any age are covered, not just recent ones.
 - Provider-ID stripping from credits, and clickable Writer / Penciller / Character links in the issue info modal.
 - Editor credits from every provider, including Metron's spelled-out editorial roles (Assistant Editor, Group Editor, Editor In Chief).
 

--- a/core/credit_backfill.py
+++ b/core/credit_backfill.py
@@ -7,21 +7,29 @@ creators in it. Nothing recovers that on its own: once ComicInfo carries a
 ``Notes`` value, every automatic tagging path treats the file as done and skips
 it forever (``app.py``, ``models/comicvine.py``, ``routes/metadata.py``).
 
-This sweep is the recovery. It picks credit-less files out of ``file_index``
-(no archive I/O to find them), re-fetches each issue from Metron through
+This sweep is the recovery. It re-fetches issues from Metron through
 ``metron.fetch_issue_detail`` -- which drops mokkari's cached body first, or the
 half-entered response would just be replayed -- and rewrites only the files
 where Metron now actually has credits.
 
-Two deliberate limits keep it cheap and self-terminating:
+Candidates come from two passes, because the two causes leave different traces:
 
-* Candidates are restricted to files whose **mtime** is recent. mtime is the
-  archive's last-write time -- writing ComicInfo rebuilds the file, so tagging
-  moves it, and ``update_file_index_from_comicinfo`` stamps the index row at that
-  moment. Nothing else does, so a comic Metron will never have credits for ages
-  out of the window instead of being re-fetched every night.
-* A file is rewritten only when the fresh payload really has credits, so a run
-  that finds nothing new touches no bytes and no mtimes.
+1. **The changed-record pass.** ``modified`` is the field that says an editor
+   finished the record, so the sweep asks Metron directly which issues changed
+   since it last ran (``metron.list_issues_modified_since``) and joins that
+   against ``file_index.ci_metronid``. This is the exact question -- it finds a
+   comic tagged a year ago whose record was completed last night, which no
+   local timestamp can reveal -- and it spends one paged list call instead of a
+   detail fetch per file.
+2. **The credit-less pass**, over recently written files. This is the safety
+   net for the other cause: when the file was tagged from a *stale cached body*,
+   Metron's record may not have changed since, so the feed in pass 1 never
+   mentions it. Recency here is the archive's mtime, stamped on the index row
+   at tag time by ``update_file_index_from_comicinfo``.
+
+Both passes share one fetch budget, and a file is rewritten only when the fresh
+payload really has credits -- so a run that finds nothing new touches no bytes
+and no mtimes.
 """
 
 import os
@@ -56,6 +64,13 @@ DEFAULT_LIMIT = 200
 # actually need fetching.
 SCAN_MULTIPLIER = 5
 MAX_SCAN = 1000
+
+# How far back the changed-record pass will ever look. mokkari follows every
+# `next` link inside a single issues_list call and below the shared pacer, so an
+# unbounded window is a long blocking burst of requests. A gap wider than this
+# is covered by the credit-less pass instead.
+MAX_LOOKBACK_DAYS = 30
+LAST_RUN_KEY = "credit_backfill_last_run"
 
 
 def _has_credits(mapping: Dict[str, Any]) -> bool:
@@ -153,8 +168,19 @@ def _resolve_metron_issue(api, file_path: str, existing: Dict[str, Any]):
         return None, None
 
 
-def backfill_file(api, file_path: str, dry_run: bool = False) -> str:
+def backfill_file(
+    api, file_path: str, dry_run: bool = False, issue_id: Optional[int] = None
+) -> str:
     """Re-fetch one file's Metron issue and add credits if Metron now has them.
+
+    Args:
+        api: Mokkari API client
+        file_path: Path to the CBZ
+        dry_run: Report what would change without writing
+        issue_id: Metron issue id when the caller already knows it (the
+            changed-record pass joins on ``ci_metronid``, so it does). Saves
+            re-deriving it from the XML, but the archive is still read: the
+            index can be stale, and the credit check has to come from the file.
 
     Returns one of ``'updated'``, ``'still-empty'``, ``'skipped'``, ``'error'``.
     """
@@ -171,13 +197,15 @@ def backfill_file(api, file_path: str, dry_run: bool = False) -> str:
         if _has_credits(existing):
             return "skipped"
 
-        issue_id, issue = _resolve_metron_issue(api, file_path, existing)
+        issue = None
+        if not issue_id:
+            issue_id, issue = _resolve_metron_issue(api, file_path, existing)
         if not issue_id:
             return "skipped"
 
         from models import metron
 
-        if issue is None:
+        if issue is None:  # noqa: SIM108 -- the resolver may have prefetched it
             issue = metron.fetch_issue_detail(
                 api, issue_id, context="(credit backfill)"
             )
@@ -214,6 +242,61 @@ def backfill_file(api, file_path: str, dry_run: bool = False) -> str:
         return "error"
 
 
+def _lookback_start(days: int) -> str:
+    """The ``YYYY-MM-DD`` lower bound for the changed-record pass.
+
+    Normally the previous run's start time, so each sweep asks only about what
+    happened since. Clamped to ``MAX_LOOKBACK_DAYS`` -- a container that has been
+    off for a year must not ask Metron for a year of edits in one paged call.
+    """
+    from core.database import get_user_preference
+
+    try:
+        last_run = float(get_user_preference(LAST_RUN_KEY) or 0)
+    except (TypeError, ValueError):
+        last_run = 0.0
+
+    now = time.time()
+    since = last_run or (now - max(1, int(days)) * 86400)
+    since = max(since, now - MAX_LOOKBACK_DAYS * 86400)
+    return time.strftime("%Y-%m-%d", time.localtime(since))
+
+
+def _changed_record_work(api, days: int, summary: Dict[str, Any]):
+    """Files whose Metron record has been edited since the last sweep.
+
+    Returns a list of ``(path, issue_id)``. Empty when Metron reports nothing,
+    when the library owns none of what changed, or -- right after the migration
+    that added the column -- while ``ci_metronid`` is still being backfilled by
+    the metadata scanner.
+    """
+    from core.database import find_files_by_metron_ids
+    from models import metron
+
+    since_date = _lookback_start(days)
+    summary["since"] = since_date
+
+    changed = metron.list_issues_modified_since(
+        api, since_date, context="(credit backfill)"
+    )
+    summary["changed_issues"] = len(changed)
+    if not changed:
+        return []
+
+    matches = find_files_by_metron_ids(changed.keys())
+    work = [
+        (path, issue_id)
+        for issue_id, paths in matches.items()
+        for path in paths
+    ]
+    summary["matched_files"] = len(work)
+    app_logger.info(
+        f"Credit backfill: {len(changed)} issue(s) changed on Metron since "
+        f"{since_date}, {len(work)} of them in the library"
+    )
+    return work
+
+
 def run_credit_backfill(
     days: int = DEFAULT_DAYS,
     limit: int = DEFAULT_LIMIT,
@@ -221,12 +304,18 @@ def run_credit_backfill(
     app=None,
     on_progress=None,
 ) -> Dict[str, Any]:
-    """Sweep recently tagged, credit-less files and repair the ones Metron can.
+    """Repair Metron-tagged files that were written without creator credits.
+
+    Runs the two passes described in the module docstring -- issues Metron has
+    edited since the last sweep, then recently written files that still have no
+    credits -- over one shared fetch budget.
 
     Args:
-        days: Only consider files modified within this many days.
+        days: Window for the credit-less pass, and the first run's lookback.
         limit: Maximum number of files to fetch from Metron in one run.
-        dry_run: Report what would change without writing anything.
+        dry_run: Report what would change without writing anything. Also leaves
+            the last-run marker alone, so the live run that follows covers the
+            same ground.
         app: Flask app to read Metron credentials from (defaults to
             ``current_app``, so a scheduled caller should pass it explicitly).
         on_progress: Optional ``(current, total, filename)`` callback, invoked
@@ -239,12 +328,15 @@ def run_credit_backfill(
     """
     from models import metron
 
+    started_at = time.time()
     summary = {
         "checked": 0,
         "updated": 0,
         "still_empty": 0,
         "skipped": 0,
         "errors": 0,
+        "changed_issues": 0,
+        "matched_files": 0,
         "stopped_early": False,
         "dry_run": bool(dry_run),
     }
@@ -255,18 +347,31 @@ def run_credit_backfill(
         summary["skipped_reason"] = "metron-unavailable"
         return summary
 
+    # Pass 1: what Metron says changed.
+    work = _changed_record_work(api, days, summary)
+
+    # Pass 2: recently written files that still have no credits. Catches the
+    # stale-cache case, where the record Metron holds never changed -- our copy
+    # of it was simply out of date when the file was tagged.
+    seen = {path for path, _ in work}
     scan_limit = min(MAX_SCAN, max(1, int(limit)) * SCAN_MULTIPLIER)
-    candidates = find_credit_less_files(days=days, limit=scan_limit)
-    if not candidates:
-        app_logger.info("Credit backfill: no credit-less files in the recent window")
+    work += [
+        (path, None)
+        for path in find_credit_less_files(days=days, limit=scan_limit)
+        if path not in seen
+    ]
+
+    if not work:
+        app_logger.info("Credit backfill: nothing to check")
+        _mark_run_complete(started_at, dry_run, summary)
         return summary
 
     app_logger.info(
-        f"Credit backfill: examining {len(candidates)} file(s) tagged in the last "
-        f"{days} days" + (" (dry run)" if dry_run else "")
+        f"Credit backfill: examining {len(work)} file(s)"
+        + (" (dry run)" if dry_run else "")
     )
 
-    for file_path in candidates:
+    for file_path, issue_id in work:
         # Only files we actually fetch for count against the budget; a file
         # skipped without touching Metron costs nothing but a zip open.
         fetched = summary["updated"] + summary["still_empty"] + summary["errors"]
@@ -285,10 +390,10 @@ def run_credit_backfill(
         summary["checked"] += 1
         if on_progress is not None:
             try:
-                on_progress(summary["checked"], len(candidates), os.path.basename(file_path))
+                on_progress(summary["checked"], len(work), os.path.basename(file_path))
             except Exception:
                 pass
-        outcome = backfill_file(api, file_path, dry_run=dry_run)
+        outcome = backfill_file(api, file_path, dry_run=dry_run, issue_id=issue_id)
         if outcome == "updated":
             summary["updated"] += 1
         elif outcome == "still-empty":
@@ -298,6 +403,8 @@ def run_credit_backfill(
         else:
             summary["skipped"] += 1
 
+    _mark_run_complete(started_at, dry_run, summary)
+
     app_logger.info(
         f"Credit backfill complete: {summary['checked']} checked, "
         f"{summary['updated']} updated, {summary['still_empty']} still empty on "
@@ -305,3 +412,25 @@ def run_credit_backfill(
         + (" (dry run)" if dry_run else "")
     )
     return summary
+
+
+def _mark_run_complete(started_at: float, dry_run: bool, summary: Dict[str, Any]) -> None:
+    """Move the changed-record cursor forward, if this run earned it.
+
+    Not after a dry run, and not after one that stopped on its budget: the
+    window has to be re-listed next time or the changes it didn't reach would
+    never be looked at again.
+
+    The marker is set a day behind the run's own start. The filter is
+    date-granular, so that is one extra page in exchange for covering a run
+    whose list call failed -- which is indistinguishable from a run where
+    nothing had changed.
+    """
+    if dry_run or summary.get("stopped_early"):
+        return
+    try:
+        from core.database import set_user_preference
+
+        set_user_preference(LAST_RUN_KEY, started_at - 86400, category="metadata")
+    except Exception as e:
+        app_logger.warning(f"Could not record credit backfill run time: {e}")

--- a/core/database.py
+++ b/core/database.py
@@ -285,6 +285,18 @@ def init_db():
                 "Migrating file_index: adding has_comicinfo column (triggering re-scan)"
             )
 
+        # Migration: Add ci_metronid so the library can be joined against
+        # Metron's "issues modified since X" feed. The id lives only inside the
+        # archive (<MetronId> in ComicInfo.xml), so without an indexed copy
+        # there is no way to answer "which of my files is this changed issue?"
+        # without opening every CBZ. NULL = not yet read, 0 = read and not a
+        # Metron file, otherwise the issue id. The 0 matters: it is what stops
+        # the backfill in core/metadata_scanner.queue_metronid_backfill() from
+        # re-queueing every ComicVine-tagged file forever.
+        if "ci_metronid" not in columns:
+            c.execute("ALTER TABLE file_index ADD COLUMN ci_metronid INTEGER")
+            app_logger.info("Migrating file_index: adding ci_metronid column")
+
         # Create indexes for file_index table
         c.execute("CREATE INDEX IF NOT EXISTS idx_file_index_name ON file_index(name)")
         c.execute(
@@ -300,6 +312,9 @@ def init_db():
         )
         c.execute(
             "CREATE INDEX IF NOT EXISTS idx_file_index_writer ON file_index(ci_writer)"
+        )
+        c.execute(
+            "CREATE INDEX IF NOT EXISTS idx_file_index_metronid ON file_index(ci_metronid)"
         )
         c.execute(
             "CREATE INDEX IF NOT EXISTS idx_file_index_first_indexed ON file_index(first_indexed_at)"
@@ -3584,6 +3599,7 @@ def update_file_metadata(file_id, metadata_dict, scanned_at, has_comicinfo=None)
                 ci_volume = ?, ci_year = ?, ci_writer = ?, ci_penciller = ?,
                 ci_inker = ?, ci_colorist = ?, ci_letterer = ?, ci_coverartist = ?,
                 ci_publisher = ?, ci_genre = ?, ci_characters = ?,
+                ci_metronid = ?,
                 metadata_scanned_at = ?, has_comicinfo = ?
             WHERE id = ?
         """,
@@ -3603,6 +3619,10 @@ def update_file_metadata(file_id, metadata_dict, scanned_at, has_comicinfo=None)
                 metadata_dict.get("ci_publisher", ""),
                 metadata_dict.get("ci_genre", ""),
                 metadata_dict.get("ci_characters", ""),
+                # This path has just read the XML, so it is the authority: 0
+                # records "read it, no MetronId there" and keeps the file out of
+                # the backfill queue.
+                _as_metron_id(metadata_dict.get("ci_metronid")) or 0,
                 scanned_at,
                 has_comicinfo if has_comicinfo is not None else 0,
                 file_id,
@@ -4016,7 +4036,8 @@ def update_file_index_from_comicinfo(file_path, comicinfo_dict):
                 ci_inker = ?, ci_colorist = ?, ci_letterer = ?, ci_coverartist = ?,
                 ci_publisher = ?, ci_genre = ?, ci_characters = ?,
                 has_comicinfo = 1, metadata_scanned_at = ?,
-                modified_at = COALESCE(?, modified_at)
+                modified_at = COALESCE(?, modified_at),
+                ci_metronid = COALESCE(?, ci_metronid)
             WHERE path = ?
             """,
             (
@@ -4027,6 +4048,12 @@ def update_file_index_from_comicinfo(file_path, comicinfo_dict):
                 ci_publisher, ci_genre, ci_characters,
                 scanned_at,
                 file_mtime,
+                # COALESCE, not a plain write: a ComicVine re-tag of a
+                # Metron-tagged file supplies no MetronId, but merge_comicinfo_bytes
+                # carries the existing <MetronId> forward into the archive. Writing
+                # 0 here would contradict the file. Left NULL, the scanner picks it
+                # up and reads the truth out of the XML.
+                _as_metron_id(comicinfo_dict.get("MetronId")),
                 file_path,
             ),
         )
@@ -4157,6 +4184,107 @@ def get_files_with_missing_comicinfo_for_rescan(limit=10000):
     except Exception as e:
         app_logger.error(f"Failed to get files for missing-XML rescan: {e}")
         return []
+
+
+def get_files_needing_metronid_backfill(limit=1000):
+    """Return already-scanned comics whose ci_metronid has never been read.
+
+    ci_metronid is written by every scan from here on, but existing rows
+    predate the column. Rather than invalidating the whole library at migration
+    time -- ``get_files_needing_metadata_scan`` skips anything with
+    has_comicinfo=1, so clearing metadata_scanned_at would not have re-queued
+    these anyway -- the scanner's queue monitor drains this query in batches
+    whenever it has nothing else to do. Each scan writes an id or 0, so the
+    result set shrinks to empty and stays there.
+
+    Args:
+        limit: Maximum number of files to return
+
+    Returns:
+        List of dicts with id, path, modified_at
+    """
+    try:
+        conn = get_db_connection()
+        if not conn:
+            return []
+
+        c = conn.cursor()
+        c.execute(
+            """
+            SELECT id, path, modified_at
+            FROM file_index
+            WHERE type = 'file'
+            AND (LOWER(path) LIKE '%.cbz' OR LOWER(path) LIKE '%.zip')
+            AND has_comicinfo = 1
+            AND ci_metronid IS NULL
+            ORDER BY modified_at DESC
+            LIMIT ?
+            """,
+            (limit,),
+        )
+
+        rows = c.fetchall()
+        conn.close()
+
+        return [
+            {"id": r["id"], "path": r["path"], "modified_at": r["modified_at"]}
+            for r in rows
+        ]
+
+    except Exception as e:
+        app_logger.error(f"Failed to get files needing ci_metronid backfill: {e}")
+        return []
+
+
+def find_files_by_metron_ids(issue_ids):
+    """Map Metron issue ids onto the files tagged from them.
+
+    This is the join that lets a sweep start from Metron's "issues modified
+    since X" feed instead of guessing from local timestamps.
+
+    Args:
+        issue_ids: Iterable of Metron issue ids
+
+    Returns:
+        Dict of ``{issue_id: [path, ...]}``. A id the library doesn't have is
+        absent; duplicates (the same issue owned twice) keep every path.
+    """
+    wanted = []
+    for raw in issue_ids or []:
+        parsed = _as_metron_id(raw)
+        if parsed is not None:
+            wanted.append(parsed)
+    if not wanted:
+        return {}
+
+    found = {}
+    try:
+        conn = get_db_connection()
+        if not conn:
+            return {}
+
+        # SQLite caps host parameters (999 on older builds), and a busy week on
+        # Metron is easily more ids than that.
+        chunk = 500
+        for start in range(0, len(wanted), chunk):
+            batch = wanted[start:start + chunk]
+            placeholders = ",".join("?" * len(batch))
+            rows = conn.execute(
+                f"""
+                SELECT path, ci_metronid FROM file_index
+                WHERE type = 'file'
+                  AND ci_metronid IN ({placeholders})
+                """,
+                batch,
+            ).fetchall()
+            for row in rows:
+                found.setdefault(row["ci_metronid"], []).append(row["path"])
+        conn.close()
+        return found
+
+    except Exception as e:
+        app_logger.error(f"Failed to map Metron issue ids to files: {e}")
+        return {}
 
 
 def get_metadata_scan_stats():
@@ -6117,6 +6245,19 @@ def _normalize_ci_value(column, value):
     if column in _NORMALIZED_SCALAR_COLUMNS:
         return strip_provider_ids(value)
     return value
+
+
+def _as_metron_id(value):
+    """Coerce a <MetronId> to a positive int, or None when there isn't one.
+
+    Providers hand this over as an int, a string or not at all, and ComicInfo
+    round-trips it as text.
+    """
+    try:
+        parsed = int(str(value).strip())
+    except (TypeError, ValueError, AttributeError):
+        return None
+    return parsed if parsed > 0 else None
 
 
 def _normalize_ci_metadata(metadata_dict):

--- a/core/metadata_scanner.py
+++ b/core/metadata_scanner.py
@@ -23,6 +23,7 @@ from core.app_logging import app_logger
 from core.config import config
 from core.database import (
     get_files_needing_metadata_scan,
+    get_files_needing_metronid_backfill,
     get_files_with_missing_comicinfo_for_rescan,
     get_metadata_scan_stats,
     update_file_metadata,
@@ -167,7 +168,12 @@ def process_metadata_scan(task):
             'ci_coverartist': metadata.get('CoverArtist', ''),
             'ci_publisher': metadata.get('Publisher', ''),
             'ci_genre': metadata.get('Genre', ''),
-            'ci_characters': metadata.get('Characters', '')
+            'ci_characters': metadata.get('Characters', ''),
+            # Indexed so the credit backfill can join Metron's "issues modified
+            # since X" feed against the library. Stored as 0 when the XML has no
+            # <MetronId>, which is also what keeps this file out of
+            # get_files_needing_metronid_backfill() on the next pass.
+            'ci_metronid': metadata.get('MetronId')
         }
 
         # Update database
@@ -343,6 +349,42 @@ def queue_missing_xml_for_rescan(limit=10000):
         return 0
 
 
+def queue_metronid_backfill(limit=1000):
+    """Queue comics indexed before ci_metronid existed so the column fills in.
+
+    Reading <MetronId> means opening the archive, which is the metadata
+    scanner's job anyway. Drained in batches by the queue monitor when nothing
+    else is pending, at the lowest priority -- this is housekeeping, not
+    something a user is waiting on. Self-terminating: every scan writes an id
+    or 0, so the underlying query empties and stays empty.
+
+    Returns:
+        Number of files queued.
+    """
+    try:
+        files = get_files_needing_metronid_backfill(limit=limit)
+
+        for f in files:
+            task = ScanTask(
+                priority=PRIORITY_BATCH,
+                file_path=f['path'],
+                file_id=f['id'],
+                modified_at=f['modified_at']
+            )
+            metadata_queue.put(task)
+
+        if files:
+            with scanner_lock:
+                scanner_progress['total_pending'] += len(files)
+            app_logger.info(f"Queued {len(files)} files to backfill ci_metronid")
+
+        return len(files)
+
+    except Exception as e:
+        app_logger.error(f"Error queuing ci_metronid backfill: {e}")
+        return 0
+
+
 def queue_monitor():
     """
     Background thread that continuously monitors and queues pending files.
@@ -367,6 +409,10 @@ def queue_monitor():
                     queued = queue_pending_files()
                     if queued > 0:
                         app_logger.info(f"Queue monitor: Queued {queued} additional files for metadata scanning")
+                else:
+                    # Nothing outstanding: spend the idle capacity filling in
+                    # ci_metronid for files indexed before the column existed.
+                    queue_metronid_backfill()
 
         except Exception as e:
             app_logger.error(f"Queue monitor error: {e}")

--- a/models/metron.py
+++ b/models/metron.py
@@ -1269,6 +1269,51 @@ def get_all_issues_for_series(api, series_id):
     )
 
 
+def list_issues_modified_since(api, since_date: str, context: str = "") -> Dict[int, str]:
+    """Ask Metron which issues its editors have touched since ``since_date``.
+
+    This is the signal a tagger actually wants: Metron records are finished
+    after a comic ships, and ``modified`` is the field that says so. Asking for
+    the changed set is one paged list call, against one detail fetch per file
+    for any approach that guesses from local timestamps instead.
+
+    ``since_date`` is a plain ``YYYY-MM-DD`` string. Metron's filter is
+    exclusive on the date, so a same-day sweep re-lists that day's changes --
+    deliberate: the overlap costs a page and closes the gap a datetime-precise
+    cursor would open around an interrupted run.
+
+    Note that mokkari follows every ``next`` link inside one call
+    (``Session._retrieve_all_results``) and does so *below* the shared pacer, so
+    the window must stay small. Callers clamp it; see
+    ``core.credit_backfill.MAX_LOOKBACK_DAYS``.
+
+    Args:
+        api: Mokkari API client
+        since_date: Lower bound, ``YYYY-MM-DD``
+        context: Extra text for the rate-limit log line
+
+    Returns:
+        ``{issue_id: modified_timestamp}``, empty on any failure.
+    """
+    if not api or not since_date:
+        return {}
+
+    params = {"modified_gt": since_date}
+    label = f"listing issues modified since {since_date}{(' ' + context) if context else ''}"
+    issues = _api_call(lambda: api.issues_list(params), label, default=[]) or []
+
+    changed = {}
+    for issue in issues:
+        issue_id = _get_attr(issue, "id", None)
+        if issue_id:
+            changed[int(issue_id)] = str(_get_attr(issue, "modified", "") or "")
+
+    app_logger.info(
+        f"Metron reports {len(changed)} issue(s) modified since {since_date}"
+    )
+    return changed
+
+
 def search_series_by_name(
     api, series_name: str, year: Optional[int] = None
 ) -> Optional[Dict[str, Any]]:

--- a/tests/integration/test_database_file_index.py
+++ b/tests/integration/test_database_file_index.py
@@ -716,3 +716,157 @@ class TestModifiedAtStampedOnTagging:
 
         assert update_file_index_from_comicinfo(path, {"Series": "Nowhere"}) is True
         assert self._modified_at(db_connection, path) == self.OLD
+
+
+class TestMetronIdIndex:
+    """ci_metronid is the join between the library and Metron's "issues modified
+    since X" feed. The id lives only inside the archive, so without an indexed
+    copy a sweep would have to open every CBZ to find out which file a changed
+    issue belongs to.
+
+    NULL means "never read the XML", 0 means "read it, not a Metron file". The
+    distinction is what makes the scanner's backfill terminate.
+    """
+
+    def test_tagging_records_the_metron_id(self, db_connection, tmp_path):
+        from core.database import (
+            add_file_index_entry,
+            update_file_index_from_comicinfo,
+        )
+
+        cbz = tmp_path / "Absolute Catwoman 003.cbz"
+        cbz.write_bytes(b"x")
+        path = str(cbz)
+        add_file_index_entry("Absolute Catwoman 003.cbz", path, "file",
+                             parent=str(tmp_path))
+
+        update_file_index_from_comicinfo(path, {"Series": "Absolute Catwoman",
+                                                "MetronId": "172615"})
+
+        assert db_connection.execute(
+            "SELECT ci_metronid FROM file_index WHERE path = ?", (path,)
+        ).fetchone()[0] == 172615
+
+    def test_a_provider_without_an_id_does_not_clear_it(self, db_connection, tmp_path):
+        """A ComicVine re-tag supplies no MetronId, but merge_comicinfo_bytes
+        carries the existing <MetronId> forward into the archive -- so blanking
+        the column here would contradict the file."""
+        from core.database import (
+            add_file_index_entry,
+            update_file_index_from_comicinfo,
+        )
+
+        cbz = tmp_path / "Batman 001.cbz"
+        cbz.write_bytes(b"x")
+        path = str(cbz)
+        add_file_index_entry("Batman 001.cbz", path, "file", parent=str(tmp_path))
+        update_file_index_from_comicinfo(path, {"MetronId": 999})
+
+        update_file_index_from_comicinfo(path, {"Series": "Batman"})
+
+        assert db_connection.execute(
+            "SELECT ci_metronid FROM file_index WHERE path = ?", (path,)
+        ).fetchone()[0] == 999
+
+    def test_the_scanner_records_zero_for_a_non_metron_file(self, db_connection):
+        """The scanner has just read the XML, so it is the authority -- and the
+        0 is what keeps the file out of the backfill queue next time."""
+        from core.database import (
+            add_file_index_entry,
+            get_files_needing_metronid_backfill,
+            update_file_metadata,
+        )
+
+        add_file_index_entry("cv.cbz", "/data/cv.cbz", "file", parent="/data")
+        fid = db_connection.execute(
+            "SELECT id FROM file_index WHERE path = ?", ("/data/cv.cbz",)
+        ).fetchone()[0]
+
+        update_file_metadata(fid, {"ci_series": "Batman"}, time.time(), 1)
+
+        assert db_connection.execute(
+            "SELECT ci_metronid FROM file_index WHERE id = ?", (fid,)
+        ).fetchone()[0] == 0
+        assert get_files_needing_metronid_backfill() == []
+
+    def test_unscanned_files_are_queued_for_backfill(self, db_connection):
+        from core.database import (
+            add_file_index_entry,
+            get_files_needing_metronid_backfill,
+        )
+
+        add_file_index_entry("old.cbz", "/data/old.cbz", "file", parent="/data")
+        db_connection.execute(
+            "UPDATE file_index SET has_comicinfo = 1 WHERE path = ?", ("/data/old.cbz",)
+        )
+        db_connection.commit()
+
+        assert [f["path"] for f in get_files_needing_metronid_backfill()] == [
+            "/data/old.cbz"
+        ]
+
+    def test_files_without_comicinfo_are_not_queued(self, db_connection):
+        """There is no id to read out of them, so they would never leave the
+        queue."""
+        from core.database import (
+            add_file_index_entry,
+            get_files_needing_metronid_backfill,
+        )
+
+        add_file_index_entry("plain.cbz", "/data/plain.cbz", "file", parent="/data")
+
+        assert get_files_needing_metronid_backfill() == []
+
+
+class TestFindFilesByMetronIds:
+
+    def _own(self, conn, path, metron_id):
+        from core.database import add_file_index_entry
+
+        add_file_index_entry(path.rsplit("/", 1)[-1], path, "file", parent="/data")
+        conn.execute(
+            "UPDATE file_index SET ci_metronid = ?, has_comicinfo = 1 WHERE path = ?",
+            (metron_id, path),
+        )
+        conn.commit()
+
+    def test_maps_ids_onto_paths(self, db_connection):
+        from core.database import find_files_by_metron_ids
+
+        self._own(db_connection, "/data/a.cbz", 172615)
+        self._own(db_connection, "/data/b.cbz", 999)
+
+        assert find_files_by_metron_ids([172615, 12345]) == {
+            172615: ["/data/a.cbz"]
+        }
+
+    def test_the_same_issue_owned_twice_keeps_both(self, db_connection):
+        from core.database import find_files_by_metron_ids
+
+        self._own(db_connection, "/data/a.cbz", 172615)
+        self._own(db_connection, "/data/dupe/a.cbz", 172615)
+
+        assert sorted(find_files_by_metron_ids([172615])[172615]) == [
+            "/data/a.cbz", "/data/dupe/a.cbz"
+        ]
+
+    def test_zero_and_junk_ids_match_nothing(self, db_connection):
+        """0 is the "scanned, not a Metron file" marker -- it must never join."""
+        from core.database import find_files_by_metron_ids
+
+        self._own(db_connection, "/data/cv.cbz", 0)
+
+        assert find_files_by_metron_ids([0, None, "", "abc"]) == {}
+
+    def test_more_ids_than_sqlite_takes_as_parameters(self, db_connection):
+        """A busy week on Metron is easily past the 999-host-parameter cap."""
+        from core.database import find_files_by_metron_ids
+
+        self._own(db_connection, "/data/deep.cbz", 2400)
+
+        assert find_files_by_metron_ids(range(1, 2500))[2400] == ["/data/deep.cbz"]
+
+    def test_no_ids_does_not_hit_the_database(self, db_connection):
+        from core.database import find_files_by_metron_ids
+
+        assert find_files_by_metron_ids([]) == {}

--- a/tests/integration/test_database_schema.py
+++ b/tests/integration/test_database_schema.py
@@ -104,6 +104,9 @@ class TestFileIndexColumns:
             "ci_year", "ci_writer", "ci_penciller", "ci_inker", "ci_colorist",
             "ci_letterer", "ci_coverartist", "ci_publisher", "ci_genre",
             "ci_characters", "metadata_scanned_at",
+            # Indexed copy of <MetronId>, so the library can be joined against
+            # Metron's "issues modified since X" feed without opening archives.
+            "ci_metronid",
         }
         assert metadata_cols.issubset(columns)
 

--- a/tests/mocked/test_metron_model.py
+++ b/tests/mocked/test_metron_model.py
@@ -370,6 +370,61 @@ class TestFetchIssueDetail:
         assert result["credits"] == [{"creator": "Bengal"}]
 
 
+class TestListIssuesModifiedSince:
+    """Metron finishes issue records after a comic ships, and ``modified`` is
+    the field that says so. Asking which issues changed is one paged list call
+    against a detail fetch per file for anything that guesses from local
+    timestamps."""
+
+    def test_filters_on_modified_gt(self):
+        from models.metron import list_issues_modified_since
+
+        api = MagicMock()
+        api.issues_list.return_value = [
+            SimpleNamespace(id=172615, modified="2026-08-26T08:35:11"),
+            SimpleNamespace(id=999, modified="2026-08-26T09:00:00"),
+        ]
+
+        changed = list_issues_modified_since(api, "2026-08-25")
+
+        api.issues_list.assert_called_once_with({"modified_gt": "2026-08-25"})
+        assert changed == {
+            172615: "2026-08-26T08:35:11",
+            999: "2026-08-26T09:00:00",
+        }
+
+    def test_no_api_or_no_date_never_calls_out(self):
+        from models.metron import list_issues_modified_since
+
+        api = MagicMock()
+        assert list_issues_modified_since(None, "2026-08-25") == {}
+        assert list_issues_modified_since(api, "") == {}
+        api.issues_list.assert_not_called()
+
+    def test_an_api_error_is_an_empty_result(self):
+        """The credit-less pass still runs, so a failed feed degrades rather
+        than taking the sweep down."""
+        from mokkari.exceptions import ApiError
+
+        from models.metron import list_issues_modified_since
+
+        api = MagicMock()
+        api.issues_list.side_effect = ApiError("boom")
+
+        assert list_issues_modified_since(api, "2026-08-25") == {}
+
+    def test_entries_without_an_id_are_dropped(self):
+        from models.metron import list_issues_modified_since
+
+        api = MagicMock()
+        api.issues_list.return_value = [
+            SimpleNamespace(id=None, modified="x"),
+            SimpleNamespace(id=7, modified=None),
+        ]
+
+        assert list_issues_modified_since(api, "2026-08-25") == {7: ""}
+
+
 class TestIsConnectionError:
 
     def test_timeout_detected(self):

--- a/tests/unit/test_credit_backfill.py
+++ b/tests/unit/test_credit_backfill.py
@@ -8,6 +8,7 @@ from churning: it only rewrites when Metron actually has credits now, and it
 never touches a file it can't identify.
 """
 import os
+import time
 import zipfile
 from unittest.mock import patch
 
@@ -186,6 +187,17 @@ class TestBackfillFile:
 
 class TestRunCreditBackfill:
 
+    @pytest.fixture(autouse=True)
+    def quiet_feed(self):
+        """Default every run to "Metron changed nothing since last time".
+
+        The changed-record pass has its own class below; these tests are about
+        the credit-less pass and the shared budget. The preference helpers are
+        stubbed because a unit test has no database behind them.
+        """
+        with patch("models.metron.list_issues_modified_since", return_value={}),              patch("core.database.get_user_preference", return_value=None),              patch("core.database.set_user_preference", return_value=True):
+            yield
+
     def test_no_metron_reports_and_stops(self):
         with patch("models.metron.get_flask_api", return_value=None):
             summary = run_credit_backfill()
@@ -292,3 +304,135 @@ class TestFindCreditLessFiles:
 
         with patch("core.database.get_db_connection", return_value=None):
             assert find_credit_less_files() == []
+
+
+class TestChangedRecordPass:
+    """Metron's ``modified`` field is the signal a tagger actually wants: it
+    says an editor finished the record. Asking Metron which issues changed and
+    joining that against ci_metronid finds a file tagged a year ago whose record
+    was completed last night -- which no local timestamp can reveal."""
+
+    @pytest.fixture(autouse=True)
+    def stub_prefs(self):
+        with patch("core.database.get_user_preference", return_value=None), \
+             patch("core.database.set_user_preference", return_value=True) as save:
+            self.save = save
+            yield
+
+    def _run(self, changed, matches, credit_less=(), **kwargs):
+        with patch("models.metron.get_flask_api", return_value=object()), \
+             patch("models.metron.list_issues_modified_since", return_value=changed), \
+             patch("core.database.find_files_by_metron_ids", return_value=matches), \
+             patch("core.credit_backfill.find_credit_less_files",
+                   return_value=list(credit_less)), \
+             patch("core.credit_backfill.backfill_file",
+                   return_value="updated") as work:
+            summary = run_credit_backfill(**kwargs)
+        return summary, work
+
+    def test_changed_issue_is_repaired_with_its_id(self):
+        """The join already knows the id, so the file is never re-derived."""
+        summary, work = self._run({172615: "2026-08-26T08:35:11"},
+                                  {172615: ["/data/DC/old.cbz"]})
+
+        assert summary["changed_issues"] == 1
+        assert summary["matched_files"] == 1
+        assert summary["checked"] == 1
+        assert work.call_args.kwargs["issue_id"] == 172615
+
+    def test_issues_the_library_does_not_own_cost_nothing(self):
+        summary, work = self._run({1: "x", 2: "y", 3: "z"}, {})
+
+        assert summary["changed_issues"] == 3
+        assert summary["matched_files"] == 0
+        assert summary["checked"] == 0
+        work.assert_not_called()
+
+    def test_a_file_in_both_passes_is_checked_once(self):
+        path = "/data/DC/Absolute Catwoman 003.cbz"
+        summary, work = self._run({172615: "x"}, {172615: [path]}, credit_less=[path])
+
+        assert summary["checked"] == 1
+        assert work.call_count == 1
+
+    def test_the_credit_less_pass_still_runs(self):
+        """It is the safety net for the stale-cache case, where Metron's record
+        never changed -- our copy of it was simply out of date."""
+        summary, work = self._run({}, {}, credit_less=["/data/DC/a.cbz"])
+
+        assert summary["checked"] == 1
+        assert work.call_args.kwargs["issue_id"] is None
+
+
+class TestChangedRecordCursor:
+
+    def _run(self, **kwargs):
+        with patch("models.metron.get_flask_api", return_value=object()), \
+             patch("models.metron.list_issues_modified_since", return_value={}), \
+             patch("core.credit_backfill.find_credit_less_files", return_value=[]), \
+             patch("core.database.get_user_preference", return_value=None), \
+             patch("core.database.set_user_preference", return_value=True) as save:
+            summary = run_credit_backfill(**kwargs)
+        return summary, save
+
+    def test_a_completed_run_moves_the_cursor(self):
+        from core.credit_backfill import LAST_RUN_KEY
+
+        before = time.time()
+        _, save = self._run()
+
+        key, value = save.call_args[0][0], save.call_args[0][1]
+        assert key == LAST_RUN_KEY
+        # Deliberately a day behind the run: the filter is date-granular, and
+        # the overlap covers a run whose list call failed silently.
+        assert before - 86400 - 5 <= value <= before - 86400 + 5
+
+    def test_a_dry_run_leaves_the_cursor_alone(self):
+        """Otherwise the live run that follows would skip what it just found."""
+        _, save = self._run(dry_run=True)
+        save.assert_not_called()
+
+    def test_a_run_that_hit_its_budget_leaves_the_cursor_alone(self):
+        with patch("models.metron.get_flask_api", return_value=object()), \
+             patch("models.metron.list_issues_modified_since", return_value={}), \
+             patch("core.credit_backfill.find_credit_less_files",
+                   return_value=["a.cbz", "b.cbz"]), \
+             patch("core.credit_backfill.backfill_file", return_value="updated"), \
+             patch("core.database.get_user_preference", return_value=None), \
+             patch("core.database.set_user_preference") as save:
+            summary = run_credit_backfill(limit=1)
+
+        assert summary["stopped_early"] is True
+        save.assert_not_called()
+
+
+class TestLookbackWindow:
+
+    def test_first_run_uses_the_days_window(self):
+        from core.credit_backfill import _lookback_start
+
+        with patch("core.database.get_user_preference", return_value=None):
+            assert _lookback_start(7) == time.strftime(
+                "%Y-%m-%d", time.localtime(time.time() - 7 * 86400)
+            )
+
+    def test_an_old_cursor_is_clamped(self):
+        """mokkari follows every `next` link inside one call and below the
+        pacer, so a container that was off for a year must not ask Metron for a
+        year of edits in one go."""
+        from core.credit_backfill import MAX_LOOKBACK_DAYS, _lookback_start
+
+        ancient = time.time() - 400 * 86400
+        with patch("core.database.get_user_preference", return_value=ancient):
+            assert _lookback_start(45) == time.strftime(
+                "%Y-%m-%d", time.localtime(time.time() - MAX_LOOKBACK_DAYS * 86400)
+            )
+
+    def test_the_stored_cursor_is_used_when_recent(self):
+        from core.credit_backfill import _lookback_start
+
+        yesterday = time.time() - 86400
+        with patch("core.database.get_user_preference", return_value=yesterday):
+            assert _lookback_start(45) == time.strftime(
+                "%Y-%m-%d", time.localtime(yesterday)
+            )

--- a/tests/unit/test_metronid_backfill.py
+++ b/tests/unit/test_metronid_backfill.py
@@ -1,0 +1,129 @@
+"""ci_metronid: the indexed copy of <MetronId> the credit backfill joins on.
+
+The id lives only inside the archive, so the metadata scanner -- which already
+opens every CBZ -- is what puts it in the index. Two things have to hold or the
+column is worse than useless: a scan must record 0 rather than NULL when the
+file has no id (NULL means "never looked", and a file that keeps coming back
+NULL is re-queued forever), and the backfill of files indexed before the column
+existed must ride the scanner's idle capacity rather than invalidating the whole
+library at migration time.
+"""
+
+import ast
+import os
+from unittest.mock import patch
+
+import pytest
+
+SCANNER_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    "core", "metadata_scanner.py",
+)
+
+
+class TestScanRecordsTheId:
+
+    def _scan(self, tmp_path, comicinfo):
+        from core.metadata_scanner import ScanTask, process_metadata_scan
+
+        cbz = tmp_path / "x.cbz"
+        cbz.write_bytes(b"x")
+        task = ScanTask(priority=1, file_path=str(cbz), file_id=7, modified_at=1.0)
+
+        with patch("core.metadata_scanner.read_comicinfo_from_zip",
+                   return_value=comicinfo), \
+             patch("core.metadata_scanner.update_file_metadata") as write:
+            process_metadata_scan(task)
+
+        return write.call_args[0][1] if write.call_args else None
+
+    def test_a_metron_tagged_file_records_its_id(self, tmp_path):
+        db_metadata = self._scan(tmp_path, {"Series": "Absolute Catwoman",
+                                            "MetronId": "172615"})
+        assert db_metadata["ci_metronid"] == "172615"
+
+    def test_a_file_without_one_records_nothing_to_parse(self, tmp_path):
+        """update_file_metadata turns this into the 0 marker; what matters here
+        is that the scanner doesn't invent a value."""
+        db_metadata = self._scan(tmp_path, {"Series": "Batman"})
+        assert db_metadata.get("ci_metronid") is None
+
+
+class TestQueueMetronidBackfill:
+
+    def test_queues_what_the_query_returns(self):
+        from core.metadata_scanner import metadata_queue, queue_metronid_backfill
+
+        rows = [{"id": 1, "path": "/data/a.cbz", "modified_at": 1.0},
+                {"id": 2, "path": "/data/b.cbz", "modified_at": 2.0}]
+
+        while not metadata_queue.empty():
+            metadata_queue.get_nowait()
+
+        with patch("core.metadata_scanner.get_files_needing_metronid_backfill",
+                   return_value=rows):
+            assert queue_metronid_backfill() == 2
+
+        assert metadata_queue.qsize() == 2
+        while not metadata_queue.empty():
+            metadata_queue.get_nowait()
+
+    def test_nothing_to_do_is_not_an_error(self):
+        from core.metadata_scanner import queue_metronid_backfill
+
+        with patch("core.metadata_scanner.get_files_needing_metronid_backfill",
+                   return_value=[]):
+            assert queue_metronid_backfill() == 0
+
+    def test_a_database_failure_is_swallowed(self):
+        """Housekeeping must never take the scanner thread down."""
+        from core.metadata_scanner import queue_metronid_backfill
+
+        with patch("core.metadata_scanner.get_files_needing_metronid_backfill",
+                   side_effect=RuntimeError("db gone")):
+            assert queue_metronid_backfill() == 0
+
+
+class TestQueueMonitorWiring:
+    """The backfill has to be the *fallback*, not an extra job: real scanning
+    work -- a new file, a modified one -- always goes first. Asserted against
+    the AST because queue_monitor is a 30-second wait loop."""
+
+    @pytest.fixture(scope="class")
+    def monitor(self):
+        with open(SCANNER_PATH, encoding="utf-8") as fh:
+            tree = ast.parse(fh.read())
+        for node in tree.body:
+            if isinstance(node, ast.FunctionDef) and node.name == "queue_monitor":
+                return node
+        pytest.fail("queue_monitor not found in core/metadata_scanner.py")
+
+    def _calls(self, node, name):
+        return [
+            child for child in ast.walk(node)
+            if isinstance(child, ast.Call)
+            and isinstance(child.func, ast.Name)
+            and child.func.id == name
+        ]
+
+    def test_backfill_runs_only_when_nothing_else_is_pending(self, monitor):
+        branches = [
+            stmt for stmt in ast.walk(monitor)
+            if isinstance(stmt, ast.If)
+            and any(self._calls(b, "queue_metronid_backfill") for b in stmt.orelse)
+        ]
+        assert len(branches) == 1, (
+            "queue_metronid_backfill belongs in exactly one else branch"
+        )
+        # ...and the branch it falls back from is the one that does real work.
+        assert any(
+            self._calls(b, "queue_pending_files") for b in branches[0].body
+        )
+
+    def test_backfill_is_not_queued_alongside_real_work(self, monitor):
+        for stmt in ast.walk(monitor):
+            if isinstance(stmt, ast.If) and any(
+                self._calls(b, "queue_metronid_backfill") for b in stmt.orelse
+            ):
+                for node in stmt.body:
+                    assert not self._calls(node, "queue_metronid_backfill")


### PR DESCRIPTION
Follow-up to #520 / #522. Every version of this sweep so far has *guessed* at which files might be stale, from local timestamps. The provider already answers the question directly.

Metron stamps each issue with `modified` — the field that moves when an editor finishes a half-entered record — and mokkari's `issues_list` takes a `modified_gt` filter (`BaseIssue` carries `modified` too). That's the same signal the other taggers key on, and it's strictly better than anything mtime can tell us.

## Two passes, one budget

1. **Changed-record pass.** Ask Metron which issues changed since the last sweep, join that against the library, repair those. One paged list call replaces a detail fetch per candidate — and it finds a comic tagged a year ago whose record was completed last night, which no local timestamp can reveal.
2. **Credit-less pass**, over recently written files — kept as the safety net for the *other* cause. When a file was tagged from a stale cached body, Metron's record may never have changed, so the feed in pass 1 never mentions it.

A file is still only rewritten when the fresh payload really has credits, so a run that finds nothing touches no bytes.

## The join: `file_index.ci_metronid`

`<MetronId>` lives only inside the archive, so there was no way to ask "which of my files is this changed issue?" without opening every CBZ. The column is indexed, and its three states matter:

| Value | Meaning |
|---|---|
| `NULL` | the XML has never been read |
| `0` | read, and not a Metron file |
| id | the Metron issue id |

The `0` is load-bearing — it's what makes the backfill of rows predating the column terminate instead of re-queueing every ComicVine-tagged file forever.

**No big-bang rescan.** New tags write the column directly; existing rows are drained in batches by the metadata scanner's queue monitor whenever it has nothing else pending, at the lowest priority. (Clearing `metadata_scanned_at` at migration time — what the `has_comicinfo` migration did — would not have worked here anyway: `get_files_needing_metadata_scan` skips anything with `has_comicinfo = 1`.)

The tagging path writes it through `COALESCE` rather than outright: a ComicVine re-tag supplies no `MetronId`, but `merge_comicinfo_bytes` carries the existing `<MetronId>` forward into the archive, so blanking the column would contradict the file. Left NULL, the scanner reads the truth back out of the XML.

## Bounds

- Lookback clamped to **30 days**. mokkari follows every `next` link inside a single `issues_list` call and does it *below* CLU's shared pacer, so an unbounded window is a long blocking burst of requests. A wider gap is covered by the credit-less pass.
- The cursor is stored a day behind the run that set it. The filter is date-granular anyway, and the overlap covers a run whose list call failed — indistinguishable from one where nothing had changed.
- A dry run, or a run that stopped on its fetch budget, leaves the cursor alone.

## Tests

`pytest`: **4255 passed, 7 skipped** (4224 before; +31).

- `tests/unit/test_credit_backfill.py` — the changed-record pass passes the known id through; issues the library doesn't own cost nothing; a file in both passes is checked once; cursor moves only on a completed live run.
- `tests/unit/test_metronid_backfill.py` — the scanner records the id, the backfill queue terminates, and (AST) the backfill sits in the queue monitor's *else* branch so real scanning work always goes first.
- `tests/integration/test_database_file_index.py` — the three column states, the ComicVine-re-tag case, and the id→path join including >999 ids (SQLite's host-parameter cap).
- `tests/mocked/test_metron_model.py` — `modified_gt` params, and a failed feed degrading to an empty result rather than taking the sweep down.

## Verifying against a live instance

```bash
# the column filling in behind the scanner
sqlite3 $CACHE_DIR/comic_utils.db \
  "SELECT COUNT(*) FILTER (WHERE ci_metronid IS NULL),
          COUNT(*) FILTER (WHERE ci_metronid > 0) FROM file_index WHERE has_comicinfo = 1;"
```

Then `POST /api/metadata/backfill-credits` with `{"dry_run": true}` — the log names the window and the count: `Metron reports N issue(s) modified since YYYY-MM-DD, M of them in the library`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
