### PR TITLE
Add a compact table view to Weekly Releases

### DIFF
--- a/templates/releases.html
+++ b/templates/releases.html
@@ -11,6 +11,18 @@
             <p class="text-muted lead mb-0">{{ date_range }}</p>
         </div>
         <div class="d-flex gap-2">
+            {% if releases %}
+            <div class="btn-group" role="group" aria-label="View mode" id="view-toggle">
+                <button type="button" class="btn btn-outline-secondary" data-view="cards" title="Card view"
+                    aria-pressed="false">
+                    <i class="bi bi-grid-3x3-gap-fill"></i>
+                </button>
+                <button type="button" class="btn btn-outline-secondary" data-view="table" title="Table view"
+                    aria-pressed="false">
+                    <i class="bi bi-list-ul"></i>
+                </button>
+            </div>
+            {% endif %}
             <div class="btn-group" role="group">
                 {% if view_mode != 'error' %}
                 <a href="{{ url_for('series.releases', date=prev_date) }}" class="btn btn-outline-primary">
@@ -59,7 +71,7 @@
         </div>
     </div>
 
-    <div class="releases-grid">
+    <div class="releases-grid" id="releases-cards">
         {% for issue in releases %}
         {% set issue_slug = generate_series_slug(issue.series.name, issue.id, issue.series.volume) %}
         {% set is_tracked = (normalize_name(issue.series.name), issue.series.volume or 0) in tracked_lookup %}
@@ -99,6 +111,59 @@
             </div>
         </a>
         {% endfor %}
+    </div>
+
+    <!-- Table View (no pagination - every release for the week is listed) -->
+    <div class="card border-0 shadow-sm d-none" id="releases-table">
+        <div class="card-body p-0">
+            <div class="table-responsive">
+                <table class="table table-sm table-hover align-middle mb-0">
+                    <thead class="table-light">
+                        <tr>
+                            <th scope="col" class="ps-4 sortable" data-sort="publisher" style="cursor: pointer;">
+                                Publisher <i class="bi bi-chevron-expand text-muted ms-1"></i>
+                            </th>
+                            <th scope="col" class="sortable" data-sort="title" style="cursor: pointer;">
+                                Series <i class="bi bi-chevron-expand text-muted ms-1"></i>
+                            </th>
+                            <th scope="col" class="sortable" data-sort="issue" style="cursor: pointer;">
+                                Issue <i class="bi bi-chevron-expand text-muted ms-1"></i>
+                            </th>
+                            <th scope="col" class="text-end pe-4">Release Date</th>
+                        </tr>
+                    </thead>
+                    <tbody id="releases-table-body">
+                        {% for issue in releases %}
+                        {% set issue_slug = generate_series_slug(issue.series.name, issue.id, issue.series.volume) %}
+                        {% set is_tracked = (normalize_name(issue.series.name), issue.series.volume or 0) in tracked_lookup %}
+                        {% set issue_url = url_for('series.issue_view', slug=issue_slug) if issue_slug else issue.resource_url %}
+                        <tr class="release-row" data-series-id="{{ issue.series.id }}"
+                            data-title="{{ issue.series.name|lower }}" data-issue="{{ issue.number or '' }}">
+                            <td class="ps-4"><span class="publisher-cell text-muted">&mdash;</span></td>
+                            <td>
+                                <a href="{{ issue_url }}" class="text-decoration-none fw-semibold">
+                                    {{ issue.series.name }}
+                                </a>
+                                {% if issue.series.volume %}
+                                <span class="text-muted small ms-1">Vol. {{ issue.series.volume }}</span>
+                                {% endif %}
+                                {% if is_tracked %}
+                                <span class="badge bg-success ms-1">Subscribed</span>
+                                {% endif %}
+                            </td>
+                            <td class="issue-number">{% if issue.number %}#{{ issue.number }}{% else %}<span
+                                    class="text-muted">&mdash;</span>{% endif %}</td>
+                            <td class="text-end pe-4">
+                                <small class="text-muted">
+                                    <i class="bi bi-calendar-event me-1"></i>{{ issue.cover_date }}
+                                </small>
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
     </div>
     {% elif not error %}
     <!-- Empty State -->
@@ -432,21 +497,156 @@
         const pillsEl = document.getElementById('publisher-pills');
         const loadingEl = document.getElementById('publisher-loading');
         const cards = Array.from(document.querySelectorAll('.release-card'));
+        const rows = Array.from(document.querySelectorAll('.release-row'));
+
+        function publisherFor(el) {
+            return publisherMap[el.dataset.seriesId] || '';
+        }
+
+        // ------------------------------------------------------------------
+        // View toggle. Cards is the default; the choice is remembered per
+        // browser so it survives sessions and week navigation.
+        // ------------------------------------------------------------------
+        const VIEW_KEY = 'releasesViewMode';
+        const toggleEl = document.getElementById('view-toggle');
+        const cardsEl = document.getElementById('releases-cards');
+        const tableEl = document.getElementById('releases-table');
+
+        function storedView() {
+            try {
+                return localStorage.getItem(VIEW_KEY);
+            } catch (e) {
+                return null;  // private mode etc.
+            }
+        }
+
+        function applyView(view) {
+            if (!cardsEl || !tableEl) return;
+            const isTable = view === 'table';
+            cardsEl.classList.toggle('d-none', isTable);
+            tableEl.classList.toggle('d-none', !isTable);
+            if (!toggleEl) return;
+            toggleEl.querySelectorAll('[data-view]').forEach(function (btn) {
+                const on = btn.dataset.view === view;
+                btn.classList.toggle('active', on);
+                btn.setAttribute('aria-pressed', on ? 'true' : 'false');
+            });
+        }
+
+        applyView(storedView() === 'table' ? 'table' : 'cards');
+        if (toggleEl) {
+            toggleEl.querySelectorAll('[data-view]').forEach(function (btn) {
+                btn.addEventListener('click', function () {
+                    const view = btn.dataset.view;
+                    try {
+                        localStorage.setItem(VIEW_KEY, view);
+                    } catch (e) { /* private mode etc. */ }
+                    applyView(view);
+                });
+            });
+        }
+
+        // ------------------------------------------------------------------
+        // Table sorting on publisher / series / issue number. Whichever column
+        // is clicked leads; the other two stay on as ascending tie-breakers, so
+        // the default ordering is publisher, then title, then issue.
+        // ------------------------------------------------------------------
+        const tbody = document.getElementById('releases-table-body');
+        const sort = { key: 'publisher', asc: true };
+        const SORT_ORDERS = {
+            publisher: ['publisher', 'title', 'issue'],
+            title: ['title', 'issue', 'publisher'],
+            issue: ['issue', 'title', 'publisher']
+        };
+
+        // "1", "0.5", "-1" and "1.MU" all sort numerically; anything with no
+        // leading number (e.g. a missing issue number) sorts last.
+        function issueValue(raw) {
+            const match = String(raw || '').match(/^-?\d+(?:\.\d+)?/);
+            return match ? parseFloat(match[0]) : Number.POSITIVE_INFINITY;
+        }
+
+        function compareRows(a, b) {
+            const order = SORT_ORDERS[sort.key] || SORT_ORDERS.publisher;
+            for (let i = 0; i < order.length; i++) {
+                const key = order[i];
+                let cmp = 0;
+                if (key === 'issue') {
+                    const av = issueValue(a.dataset.issue);
+                    const bv = issueValue(b.dataset.issue);
+                    cmp = av === bv
+                        ? String(a.dataset.issue || '').localeCompare(String(b.dataset.issue || ''))
+                        : av - bv;
+                } else if (key === 'publisher') {
+                    const av = publisherFor(a);
+                    const bv = publisherFor(b);
+                    // Unidentified publishers always sink to the bottom.
+                    if (!av !== !bv) return av ? -1 : 1;
+                    cmp = av.localeCompare(bv);
+                } else {
+                    cmp = (a.dataset.title || '').localeCompare(b.dataset.title || '');
+                }
+                if (cmp) return key === sort.key && !sort.asc ? -cmp : cmp;
+            }
+            return 0;
+        }
+
+        function applySort() {
+            if (!tbody) return;
+            rows.slice().sort(compareRows).forEach(function (row) {
+                tbody.appendChild(row);
+            });
+            document.querySelectorAll('#releases-table .sortable').forEach(function (th) {
+                const icon = th.querySelector('i');
+                if (!icon) return;
+                icon.className = th.dataset.sort === sort.key
+                    ? (sort.asc ? 'bi bi-chevron-up text-primary ms-1' : 'bi bi-chevron-down text-primary ms-1')
+                    : 'bi bi-chevron-expand text-muted ms-1';
+            });
+        }
+
+        // The publisher cells are filled client-side for the same reason the
+        // pills are: the server only knows part of the map when the page ships.
+        function syncPublisherCells() {
+            rows.forEach(function (row) {
+                const cell = row.querySelector('.publisher-cell');
+                if (!cell) return;
+                const pub = publisherFor(row);
+                cell.textContent = pub || '\u2014';
+                cell.className = pub
+                    ? 'publisher-cell badge bg-secondary'
+                    : 'publisher-cell text-muted';
+            });
+        }
+
+        document.querySelectorAll('#releases-table .sortable').forEach(function (th) {
+            th.addEventListener('click', function () {
+                const key = th.dataset.sort;
+                if (!SORT_ORDERS[key]) return;
+                if (sort.key === key) {
+                    sort.asc = !sort.asc;
+                } else {
+                    sort.key = key;
+                    sort.asc = true;
+                }
+                applySort();
+            });
+        });
+
+        syncPublisherCells();
+        applySort();
+
         if (!filterBar || !pillsEl || !cards.length) return;
 
         const UNKNOWN = '__unknown__';
         let selected = new URLSearchParams(window.location.search).get('publisher') || '';
 
-        function publisherFor(card) {
-            return publisherMap[card.dataset.seriesId] || '';
-        }
-
         function applyFilter() {
-            cards.forEach(function (card) {
-                const pub = publisherFor(card);
+            cards.concat(rows).forEach(function (el) {
+                const pub = publisherFor(el);
                 const match = !selected
                     || (selected === UNKNOWN ? !pub : pub === selected);
-                card.classList.toggle('d-none', !match);
+                el.classList.toggle('d-none', !match);
             });
         }
 
@@ -547,6 +747,8 @@
                     .then(function (data) {
                         if (!data.success) return;
                         Object.assign(publisherMap, data.publishers || {});
+                        syncPublisherCells();
+                        applySort();
                         render();
                         applyFilter();
                         if (!data.pending) {

--- a/tests/routes/test_series_routes.py
+++ b/tests/routes/test_series_routes.py
@@ -1263,10 +1263,8 @@ class TestReleasesPublisherFilter:
         resp = client.get("/releases")
         assert resp.status_code == 200
 
-    def test_page_renders_the_filter_and_tags_every_card(self, client, app):
-        # The pills are built client-side from these two things: the serialized
-        # map and a data-series-id on each card. If either stops rendering, the
-        # filter silently disappears.
+    def _render_releases_page(self, client, app):
+        """Render /releases with two issues (one publisher known) and return the HTML."""
         from datetime import datetime
         from core.database import save_series_publishers
 
@@ -1286,13 +1284,52 @@ class TestReleasesPublisherFilter:
             ]
             resp = client.get("/releases?date=2024-01-10")
 
-        html = resp.get_data(as_text=True)
         assert resp.status_code == 200
+        return resp.get_data(as_text=True)
+
+    def test_page_renders_the_filter_and_tags_every_card(self, client, app):
+        # The pills are built client-side from these two things: the serialized
+        # map and a data-series-id on each card. If either stops rendering, the
+        # filter silently disappears.
+        html = self._render_releases_page(client, app)
+
         assert 'id="publisher-filter"' in html
-        assert html.count("data-series-id=") == 2
+        # Both views carry the tag -- the filter hides cards and rows alike.
+        assert html.count("release-card stagger-load") == 2
+        assert html.count('class="release-row"') == 2
+        assert html.count("data-series-id=") == 4
         # JSON keys are strings, matching the dataset lookup in the template.
         assert 'const publisherMap = {"11": "Marvel"}' in html
         assert "const pendingWarm = true" in html
+
+    def test_page_renders_both_views_with_a_toggle(self, client, app):
+        # Cards and the table are rendered together and swapped client-side, so
+        # the table needs no pagination and the toggle no round trip.
+        html = self._render_releases_page(client, app)
+
+        assert 'id="view-toggle"' in html
+        assert 'id="releases-cards"' in html
+        assert 'id="releases-table"' in html
+        # Table starts hidden: cards are the default until localStorage says otherwise.
+        assert 'class="card border-0 shadow-sm d-none" id="releases-table"' in html
+        assert "const VIEW_KEY = 'releasesViewMode'" in html
+
+        # Covers belong to the cards; the table stays compact and text-only.
+        cards = html[html.index('id="releases-cards"'):html.index('id="releases-table"')]
+        table = html[html.index('id="releases-table"'):html.index("<style>")]
+        assert cards.count("<img") == 2  # one per card
+        assert "<img" not in table
+
+    def test_table_view_sorts_on_publisher_title_and_issue(self, client, app):
+        html = self._render_releases_page(client, app)
+
+        for key in ("publisher", "title", "issue"):
+            assert f'sortable" data-sort="{key}"' in html
+        # Publisher is resolved client-side, so each row ships an empty cell
+        # that syncPublisherCells() fills as the map arrives.
+        assert html.count('class="publisher-cell text-muted"') == 2
+        assert html.count('data-title="series 11"') == 1
+        assert html.count('data-issue="1"') == 2
 
     # -- warm pass --------------------------------------------------------
     def test_warm_pass_bulk_resolves_by_known_publisher(self, db_connection):


### PR DESCRIPTION
Cards stay the default, but a header toggle now swaps the week's releases for a paginationless table sorted on publisher, series and issue number.

## What changed

- **View toggle** (`templates/releases.html`) — a two-button group in the header, rendered only when there are releases. The choice is written to `localStorage` under `releasesViewMode` and read back on load, so it survives sessions and week navigation. The access is wrapped in try/catch for private-mode browsers, matching `static/js/collection.js`.
- **Table view** — columns are Publisher, Series (with volume and a "Subscribed" badge), Issue, and Release Date. Both views ship in the same response and are swapped client-side, so switching costs no round trip and the table can list the whole week at once. It follows the `sortable` / `data-sort` convention already used in `pull_list.html`.
- **Publisher filter** — now toggles table rows alongside cards.

## Two details the sorting has to get right

- Whichever column leads, the other two stay on as ascending tie-breakers, so the default order is publisher → series → issue.
- Issue numbers sort off their leading number rather than lexically, so `-1 < 1 < 1.MU < 2 < 10`. Rows with no issue number, and rows whose publisher is still unidentified, sink to the bottom.

Each row's publisher cell is filled client-side from the same map the filter pills use. That is forced by the existing design: Metron's issue payload carries no publisher, so the map arrives in the background and the table re-syncs and re-sorts on each poll tick.

Covers are a card affordance only — the table is text-only and `table-sm`, so a week's worth of releases stays scannable.

## Testing

`tests/routes/test_series_routes.py` — the existing `data-series-id` count assertion had to change (2 → 4, since both views tag their elements), plus two new tests covering the toggle markup and the sortable columns, one of which pins covers to the cards grid.

Beyond the suite, I rendered the real page through the Flask test client and drove it in jsdom to confirm the toggle persists and restores, all three sorts order correctly (including the `1.MU` and `-1` cases above), and the filter hides rows and cards together.

Full suite: 4264 passed, 7 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
