### PR TITLE
Replace the collection pager's per-page mirror with a Jump to page select

### DIFF
--- a/static/css/collection.css
+++ b/static/css/collection.css
@@ -339,8 +339,15 @@ body.collection-select-mode {
     animation: slideUp 0.3s ease-out;
 }
 
-#pagination-controls .pager-perpage {
+#pagination-controls .pager-jump {
     width: auto;
+}
+
+/* Size to the widest "N of N" option rather than stretching to fill the pager row,
+   which is what an .input-group child does by default. */
+#pagination-controls #pageJumpSelect {
+    width: auto;
+    flex: 0 0 auto;
 }
 
 /* Full body colour, not --bs-secondary-color: any mix toward the background can
@@ -357,7 +364,7 @@ body.collection-select-mode {
 }
 
 #pagination-controls.is-busy .page-link,
-#pagination-controls.is-busy #itemsPerPageFloating {
+#pagination-controls.is-busy .pager-jump select {
     pointer-events: none;
 }
 

--- a/static/js/collection.js
+++ b/static/js/collection.js
@@ -8,9 +8,6 @@
 // Update XML – field config and current path now in clu-update-xml.js
 
 document.addEventListener('DOMContentLoaded', () => {
-    // Mirror the per-page options into the sticky pager before restoring the saved
-    // preference, so both selects land on the same value.
-    initItemsPerPageMirror();
     // Restore saved items-per-page preference before the first directory load
     restoreItemsPerPage();
     restoreCardSize();
@@ -2443,6 +2440,8 @@ function renderPagination(totalItems) {
             `${itemCount.toLocaleString()} · page ${currentPage} of ${totalPages}`;
     }
 
+    syncPageJumpSelect(totalPages);
+
     if (focusKey) {
         // Fall back down the chain for the case where the previously focused control is
         // now disabled (e.g. clicking Next onto the last page).
@@ -2493,11 +2492,40 @@ function changePage(page) {
 }
 
 /**
- * Jump to a specific page from the dropdown selector.
+ * Jump to a specific page.
  * @param {string|number} page - The page number to jump to.
  */
 function jumpToPage(page) {
     changePage(parseInt(page));
+}
+
+/**
+ * Fill the sticky pager's "Jump to" select with one option per page and select the
+ * current one. Offering only real pages is what keeps an out-of-range jump impossible.
+ *
+ * The options are rebuilt only when the page count actually changes: renderPagination()
+ * runs on every page click, and a 250-page library would otherwise churn 250 nodes each
+ * time for a list that has not moved.
+ * @param {number} totalPages - The number of pages currently available.
+ */
+function syncPageJumpSelect(totalPages) {
+    const select = document.getElementById('pageJumpSelect');
+    if (!select) return;
+
+    if (select.dataset.totalPages !== String(totalPages)) {
+        const options = document.createDocumentFragment();
+        for (let p = 1; p <= totalPages; p++) {
+            const opt = document.createElement('option');
+            opt.value = String(p);
+            opt.textContent = `${p} of ${totalPages}`;
+            options.appendChild(opt);
+        }
+        select.innerHTML = '';
+        select.appendChild(options);
+        select.dataset.totalPages = String(totalPages);
+    }
+
+    select.value = String(currentPage);
 }
 
 /**
@@ -2614,31 +2642,15 @@ function restoreCardSize() {
 }
 
 /**
- * Keep the filter-bar per-page select and its mirror in the sticky pager in step.
- * @param {string} value - The option value to select on both controls.
+ * Point the filter-bar per-page select at a value.
+ *
+ * #itemsPerPage is the single source of truth for the allowed values --
+ * restoreItemsPerPage() validates the saved preference against its options.
+ * @param {string} value - The option value to select.
  */
 function syncItemsPerPageSelects(value) {
-    ['itemsPerPage', 'itemsPerPageFloating'].forEach(id => {
-        const el = document.getElementById(id);
-        if (el && el.value !== value) el.value = value;
-    });
-}
-
-/**
- * Populate the sticky pager's per-page select from the filter-bar one.
- *
- * The options are cloned rather than duplicated in the template on purpose:
- * restoreItemsPerPage() validates the saved preference against #itemsPerPage's options,
- * so that control has to stay the single source of truth for the allowed values.
- */
-function initItemsPerPageMirror() {
-    const source = document.getElementById('itemsPerPage');
-    const mirror = document.getElementById('itemsPerPageFloating');
-    if (!source || !mirror) return;
-
-    mirror.innerHTML = '';
-    Array.from(source.options).forEach(opt => mirror.appendChild(opt.cloneNode(true)));
-    mirror.value = source.value;
+    const el = document.getElementById('itemsPerPage');
+    if (el && el.value !== value) el.value = value;
 }
 
 /**

--- a/templates/collection.html
+++ b/templates/collection.html
@@ -154,10 +154,14 @@
                         aria-live="polite" aria-atomic="true"></div>
                     <ul class="pagination pagination-sm justify-content-center flex-wrap mb-0" id="pagination-list">
                     </ul>
-                    <div class="pager-perpage input-group input-group-sm d-none d-md-flex">
-                        <label class="input-group-text" for="itemsPerPageFloating">Per page</label>
-                        <select class="form-select" id="itemsPerPageFloating"
-                            onchange="changeItemsPerPage(this.value)"></select>
+                    {# Jump-to-page: the windowed number list only reaches currentPage
+                       +/- 2, so a long library has no way to reach the middle. Options are
+                       filled in by renderPagination(), which is also what makes an
+                       out-of-range page unreachable -- there is nothing to type. #}
+                    <div class="pager-jump input-group input-group-sm d-none d-md-flex">
+                        <label class="input-group-text" for="pageJumpSelect">Jump to</label>
+                        <select class="form-select" id="pageJumpSelect" aria-label="Jump to page"
+                            onchange="jumpToPage(this.value)"></select>
                     </div>
                 </div>
             </nav>


### PR DESCRIPTION
## What

The sticky pager on **Browse Library** carried a per-page `<select>` that was a
mirror of the one in the filter bar three rows above it. This replaces that slot
with a **Jump to** page select.

## Why

The pager's windowed number list only reaches `currentPage ± 2` (plus first and
last), so on a library running to dozens of pages the middle was unreachable
without repeated clicking. The slot next to it was spent on a duplicate control.

A `<select>` rather than a number box: it can only offer pages that exist, so an
out-of-range jump is impossible by construction — no validation, no error state,
no Go button. Picking a page navigates immediately.

## Changes

- **`templates/collection.html`** — `.pager-perpage` → `.pager-jump`: a label and
  `#pageJumpSelect` with `onchange="jumpToPage(this.value)"`. Same
  `d-none d-md-flex` breakpoint as before, so mobile is unchanged. Per-page still
  lives in the filter bar.
- **`static/js/collection.js`**
  - New `syncPageJumpSelect(totalPages)`, called from `renderPagination()`. Builds
    one option per page labelled `"3 of 47"` and selects the current one.
  - Options are rebuilt **only** when `totalPages` changes (tracked on
    `dataset.totalPages`). `renderPagination()` fires on every page click, and a
    250-page library would otherwise churn 250 nodes each time for a list that has
    not moved; a normal page change now just moves the selection.
  - Removed `initItemsPerPageMirror()` and its `DOMContentLoaded` call;
    `syncItemsPerPageSelects()` collapses to the one remaining `#itemsPerPage`
    select, which stays the single source of truth for the allowed per-page values
    (`restoreItemsPerPage()` validates the saved preference against its options).
- **`static/css/collection.css`** — `.pager-perpage` rules → `.pager-jump`;
  `#pageJumpSelect` gets `width: auto; flex: 0 0 auto` so it sizes to its widest
  option instead of stretching to fill the row as an `.input-group` child does by
  default. The `.is-busy` pointer-events lock now targets `.pager-jump select`.

## Testing

`pytest` — **4264 passed, 7 skipped** (the skips are the usual POSIX/symlink ones
on Windows). No leftover references to `itemsPerPageFloating` /
`initItemsPerPageMirror` anywhere in `static/`, `templates/` or `tests/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
