### PR TITLE
Bring the second GCD search loop to parity, and rank tokenized matches by year

### DIFF
--- a/models/gcd.py
+++ b/models/gcd.py
@@ -33,10 +33,10 @@ MAIN_WORD_VARIATIONS = frozenset({"main_only", "main_with_year"})
 # only tier that still matches when the filename's year falls outside the
 # series' GCD run (a reprint year, a collected edition, a mis-parsed year),
 # which is precisely when every variation above it has already failed for the
-# same reason. The cost is real and known: `tokenized` takes the first row of
-# `ORDER BY year_began DESC`, so where several series contain all the tokens a
-# newer one wins over the right era. Narrowing that is a ranking problem, not
-# a filtering one.
+# same reason. It is not year-blind, though: where several series contain all
+# the tokens, the parsed year picks the closest era rather than the newest.
+# That is a ranking problem, not a filtering one, and it is solved as one --
+# see `proximity_suffix` in search_series().
 YEAR_CONSTRAINED_VARIATIONS = frozenset({
     "exact", "no_issue", "no_year", "no_dash", "main_with_year",
 })
@@ -556,6 +556,17 @@ def search_series(series_name: str, year: int = None, language_codes: List[str] 
                 )
                 lang_filter = ' AND l.code IN (' + lang_placeholders + ')'
                 order_suffix = ' ORDER BY s.year_began DESC LIMIT 10'
+                # `tokenized` is not year-*filtered* (see
+                # YEAR_CONSTRAINED_VARIATIONS), but when the filename supplied a
+                # year there is no reason to break its ties by recency. Ranking
+                # by distance from the parsed year only decides which of several
+                # all-token matches wins -- it can never drop one. COALESCE
+                # keeps a NULL year_began sorting last: ABS(NULL - y) is NULL,
+                # and SQLite sorts NULLs first on ASC.
+                proximity_suffix = (
+                    ' ORDER BY ABS(COALESCE(s.year_began, 9999) - ?) ASC,'
+                    ' s.year_began DESC LIMIT 10'
+                )
 
                 # Decline the one-token fallback when it cannot narrow the
                 # field to something rankable. See main_word_token_too_broad().
@@ -571,11 +582,18 @@ def search_series(series_name: str, year: int = None, language_codes: List[str] 
                     continue
 
                 if search_type == "tokenized":
-                    # REGEXP search
-                    query = (base_select
-                             + ' WHERE LOWER(s.name) REGEXP ?'
-                             + lang_filter + order_suffix)
-                    cursor.execute(query, (search_pattern.lower(), *language_codes))
+                    # REGEXP search, ranked by year proximity when we have one.
+                    if year:
+                        query = (base_select
+                                 + ' WHERE LOWER(s.name) REGEXP ?'
+                                 + lang_filter + proximity_suffix)
+                        cursor.execute(query,
+                                       (search_pattern.lower(), *language_codes, year))
+                    else:
+                        query = (base_select
+                                 + ' WHERE LOWER(s.name) REGEXP ?'
+                                 + lang_filter + order_suffix)
+                        cursor.execute(query, (search_pattern.lower(), *language_codes))
                 elif year and search_type in YEAR_CONSTRAINED_VARIATIONS:
                     # Year-constrained LIKE search. `main_with_year` belongs here:
                     # it was named for a year it never applied, because it was

--- a/models/gcd.py
+++ b/models/gcd.py
@@ -26,8 +26,17 @@ MAIN_WORD_VARIATIONS = frozenset({"main_only", "main_with_year"})
 # Variations that constrain results to series actually running in the parsed
 # year, when the filename supplied one. `main_with_year` is included because
 # that is what its name promises; `main_only` is what the same variation is
-# called when no year is available. `tokenized` is deliberately absent -- it
-# runs through the REGEXP branch, which has no year clause.
+# called when no year is available.
+#
+# `tokenized` is deliberately absent, and not merely because it runs through
+# the REGEXP branch -- that branch could take the same two bindings. It is the
+# only tier that still matches when the filename's year falls outside the
+# series' GCD run (a reprint year, a collected edition, a mis-parsed year),
+# which is precisely when every variation above it has already failed for the
+# same reason. The cost is real and known: `tokenized` takes the first row of
+# `ORDER BY year_began DESC`, so where several series contain all the tokens a
+# newer one wins over the right era. Narrowing that is a ranking problem, not
+# a filtering one.
 YEAR_CONSTRAINED_VARIATIONS = frozenset({
     "exact", "no_issue", "no_year", "no_dash", "main_with_year",
 })
@@ -79,6 +88,42 @@ def tokens_for_all_match(s: str):
     norm = normalize_title(s)
     toks = [t for t in norm.split() if t not in STOPWORDS]
     return norm, toks
+
+
+def main_word_token_too_broad(cursor, search_pattern: str, language_codes) -> bool:
+    """True when a main-word LIKE pattern matches more series than can be ranked.
+
+    The main-word fallback searches a single token as an unanchored substring,
+    so a short or common token matches an enormous slice of the database --
+    '%le%' matches 18,526 series in the current dump. Ordering those by year and
+    taking the first does not pick the best candidate, it picks the most
+    recently started one, which is how an Italian Disney part-work ends up
+    tagged as a 2026 Harley Quinn book. When the token cannot narrow the field
+    to something rankable, the caller must decline instead of guessing.
+
+    The probe deliberately ignores any year filter the caller is about to apply.
+    How discriminating a token is, is a property of the token: '%diabolik%'
+    matches 15 series whichever year is asked for. Measuring the year-filtered
+    set instead would let the year clause shrink an over-broad token under the
+    cap and hand back an arbitrary pick from whatever happened to be running
+    that year.
+
+    Shared by both progressive-search loops -- ``search_series`` here and
+    ``search_gcd_metadata`` in ``routes/metadata.py`` -- so the two cannot drift
+    apart on the policy the way they did on the year constraint.
+    """
+    codes = list(language_codes or [])
+    # Mirrors the callers' own empty-list handling: "IN (NULL)" matches nothing
+    # rather than being a syntax error.
+    in_clause = ','.join(['?'] * len(codes)) if codes else 'NULL'
+    cursor.execute(
+        'SELECT 1 FROM gcd_series s'
+        ' JOIN stddata_language l ON s.language_id = l.id'
+        ' WHERE s.name LIKE ? AND l.code IN (' + in_clause + ')'
+        + f' LIMIT {MAIN_WORD_MAX_CANDIDATES + 1}',
+        (search_pattern, *codes),
+    )
+    return len(cursor.fetchall()) > MAIN_WORD_MAX_CANDIDATES
 
 
 def lookahead_regex(toks):
@@ -512,37 +557,18 @@ def search_series(series_name: str, year: int = None, language_codes: List[str] 
                 lang_filter = ' AND l.code IN (' + lang_placeholders + ')'
                 order_suffix = ' ORDER BY s.year_began DESC LIMIT 10'
 
-                # The main-word fallback searches a single token as an unanchored
-                # substring, so a short or common token matches an enormous slice
-                # of the database -- '%le%' matches 18,526 series in the current
-                # dump. Ordering those by year and taking the first does not pick
-                # the best candidate, it picks the most recently started one, which
-                # is how an Italian Disney part-work ends up tagged as a 2026
-                # Harley Quinn book. When the token cannot narrow the field to
-                # something rankable, decline instead of guessing.
-                #
-                # The probe deliberately ignores the year filter. How
-                # discriminating a token is, is a property of the token: '%diabolik%'
-                # matches 15 series whichever year is asked for. Measuring the
-                # year-filtered set instead would let the year clause shrink an
-                # over-broad token under the cap and hand back an arbitrary pick
-                # from whatever happened to be running that year.
-                if search_type in MAIN_WORD_VARIATIONS:
-                    cursor.execute(
-                        'SELECT 1 FROM gcd_series s'
-                        ' JOIN stddata_language l ON s.language_id = l.id'
-                        ' WHERE s.name LIKE ?' + lang_filter
-                        + f' LIMIT {MAIN_WORD_MAX_CANDIDATES + 1}',
-                        (search_pattern, *language_codes),
+                # Decline the one-token fallback when it cannot narrow the
+                # field to something rankable. See main_word_token_too_broad().
+                if search_type in MAIN_WORD_VARIATIONS and main_word_token_too_broad(
+                    cursor, search_pattern, language_codes
+                ):
+                    app_logger.info(
+                        f"GCD search_series: Skipping {search_type} for "
+                        f"'{series_name}' -- '{search_pattern}' matches more "
+                        f"than {MAIN_WORD_MAX_CANDIDATES} series, too broad "
+                        f"to rank"
                     )
-                    if len(cursor.fetchall()) > MAIN_WORD_MAX_CANDIDATES:
-                        app_logger.info(
-                            f"GCD search_series: Skipping {search_type} for "
-                            f"'{series_name}' -- '{search_pattern}' matches more "
-                            f"than {MAIN_WORD_MAX_CANDIDATES} series, too broad "
-                            f"to rank"
-                        )
-                        continue
+                    continue
 
                 if search_type == "tokenized":
                     # REGEXP search

--- a/routes/metadata.py
+++ b/routes/metadata.py
@@ -2018,6 +2018,18 @@ def search_gcd_metadata():
                             + ' WHERE LOWER(s.name) REGEXP ?'
                             + lang_filter + order_suffix)
 
+            # `tokenized` is not year-filtered (it is the tier that still
+            # matches when the filename year falls outside the series' run),
+            # but when a year was parsed its ties are broken by proximity to
+            # that year rather than by recency. COALESCE keeps a NULL
+            # year_began sorting last rather than first.
+            regexp_query_by_year_proximity = (
+                base_select
+                + ' WHERE LOWER(s.name) REGEXP ?'
+                + lang_filter
+                + ' ORDER BY ABS(COALESCE(s.year_began, 9999) - ?) ASC, s.year_began DESC'
+            )
+
             # Try each search variation progressively
             app_logger.debug(f"DEBUG: Starting search loop with {len(search_variations)} variations")
             for search_type, search_pattern in search_variations:
@@ -2039,7 +2051,11 @@ def search_gcd_metadata():
 
                     if search_type == "tokenized":
                         # Use REGEXP for tokenized search (pattern should be lowercase for LOWER(s.name))
-                        cursor.execute(regexp_query, (search_pattern.lower(), *in_params))
+                        if year:
+                            cursor.execute(regexp_query_by_year_proximity,
+                                           (search_pattern.lower(), *in_params, year))
+                        else:
+                            cursor.execute(regexp_query, (search_pattern.lower(), *in_params))
 
                     elif year and search_type in gcd.YEAR_CONSTRAINED_VARIATIONS:
                         # Year-constrained search when year is available.

--- a/routes/metadata.py
+++ b/routes/metadata.py
@@ -2024,12 +2024,28 @@ def search_gcd_metadata():
                 app_logger.debug(f"DEBUG: Trying {search_type} search with pattern: {search_pattern}")
 
                 try:
+                    # Same guard the automatic path applies: a one-token
+                    # substring like '%le%' matches 18,526 series, and this
+                    # query has no LIMIT, so without it the whole slice is
+                    # ranked by year and shipped to the selection modal.
+                    if search_type in gcd.MAIN_WORD_VARIATIONS and gcd.main_word_token_too_broad(
+                        cursor, search_pattern, languages
+                    ):
+                        app_logger.debug(
+                            f"DEBUG: Skipping {search_type} -- '{search_pattern}' matches "
+                            f"more than {gcd.MAIN_WORD_MAX_CANDIDATES} series, too broad to rank"
+                        )
+                        continue
+
                     if search_type == "tokenized":
                         # Use REGEXP for tokenized search (pattern should be lowercase for LOWER(s.name))
                         cursor.execute(regexp_query, (search_pattern.lower(), *in_params))
 
-                    elif year and search_type in ["exact", "no_issue", "no_year", "no_dash"]:
-                        # Year-constrained search when year is available
+                    elif year and search_type in gcd.YEAR_CONSTRAINED_VARIATIONS:
+                        # Year-constrained search when year is available.
+                        # `main_with_year` is in that set: it used to be missing
+                        # from a literal list here, so the variation named for a
+                        # year never applied one.
                         cursor.execute(like_query_with_year, (search_pattern, year, year, *in_params))
 
                     else:

--- a/tests/mocked/test_gcd_model.py
+++ b/tests/mocked/test_gcd_model.py
@@ -429,3 +429,48 @@ class TestMainWordProbeIgnoresTheYear:
         assert result is not None
         # 'Zorro Returns' (2020) is the newest, but it was not running in 1955.
         assert result["name"] == "Zorro"
+
+    def test_exactly_the_cap_is_within_it(self, many_zorros, monkeypatch):
+        """Three series contain 'zorro', so a cap of three must still allow it.
+
+        Pins the boundary: with only the over/under tests, flipping the
+        comparison to `>=` passes.
+        """
+        import models.gcd as gcd
+        monkeypatch.setattr(gcd, "MAIN_WORD_MAX_CANDIDATES", 3)
+        result = gcd.search_series("Zorro Special Annual Edition", year=1955)
+        assert result is not None
+        assert result["name"] == "Zorro"
+
+    def test_one_over_the_cap_is_declined(self, many_zorros, monkeypatch):
+        """The other side of the same boundary."""
+        import models.gcd as gcd
+        monkeypatch.setattr(gcd, "MAIN_WORD_MAX_CANDIDATES", 2)
+        assert gcd.search_series("Zorro Special Annual Edition", year=1955) is None
+
+
+class TestMainWordTokenTooBroad:
+    """The probe helper is shared with routes/metadata.py, so test it directly."""
+
+    def _cursor(self, tmp_path):
+        path = build_gcd_sqlite(tmp_path / "probe.db")
+        conn = sqlite3.connect(path)
+        conn.row_factory = lambda c, r: {d[0]: r[i] for i, d in enumerate(c.description)}
+        return conn.cursor()
+
+    def test_a_narrow_token_is_not_too_broad(self, tmp_path):
+        from models.gcd import main_word_token_too_broad
+        assert main_word_token_too_broad(self._cursor(tmp_path), "%batman%", ["en"]) is False
+
+    def test_the_language_filter_applies_to_the_probe(self, tmp_path, monkeypatch):
+        """Diabolik is Italian, so an English-only probe must not count it."""
+        import models.gcd as gcd
+        cursor = self._cursor(tmp_path)
+        monkeypatch.setattr(gcd, "MAIN_WORD_MAX_CANDIDATES", 0)
+        assert gcd.main_word_token_too_broad(cursor, "%diabolik%", ["en"]) is False
+        assert gcd.main_word_token_too_broad(cursor, "%diabolik%", ["it"]) is True
+
+    def test_no_configured_languages_matches_nothing(self, tmp_path):
+        """Empty codes must produce "IN (NULL)", not a SQL syntax error."""
+        from models.gcd import main_word_token_too_broad
+        assert main_word_token_too_broad(self._cursor(tmp_path), "%batman%", []) is False

--- a/tests/mocked/test_gcd_model.py
+++ b/tests/mocked/test_gcd_model.py
@@ -449,6 +449,87 @@ class TestMainWordProbeIgnoresTheYear:
         assert gcd.search_series("Zorro Special Annual Edition", year=1955) is None
 
 
+class TestTokenizedYearProximity:
+    """`tokenized` is not year-filtered, but a parsed year still breaks its ties.
+
+    It is the tier that survives when the filename's year falls outside the
+    series' GCD run, so it must not be year-*constrained*. Ordering its hits by
+    recency instead of by distance from the parsed year meant that where several
+    series contain every token, a newer one won over the right era.
+    """
+
+    @pytest.fixture
+    def two_rebirths(self, tmp_path, monkeypatch):
+        """Two series containing all four tokens, five years apart.
+
+        Neither name contains the parsed title as a literal substring, so
+        `exact` cannot match and `tokenized` is genuinely the deciding tier.
+        """
+        path = build_gcd_sqlite(tmp_path / "rebirth.db")
+        conn = sqlite3.connect(path)
+        conn.executemany(
+            "INSERT INTO gcd_series (id, name, year_began, year_ended, "
+            "publisher_id, language_id) VALUES (?, ?, ?, ?, ?, ?)",
+            [(400, "Batman: Detective Comics - Rebirth", 2018, None, 10, 1),
+             (401, "Detective Comics: Batman Rebirth Deluxe", 2023, None, 10, 1)],
+        )
+        conn.commit()
+        conn.close()
+        monkeypatch.setattr("models.gcd._get_saved_credentials",
+                            lambda: {"database_path": str(path)})
+        return path
+
+    def test_the_parsed_year_picks_the_closest_era(self, two_rebirths):
+        from models.gcd import search_series
+        result = search_series("Batman Detective Comics Rebirth", year=2018)
+        assert result is not None
+        assert result["year_began"] == 2018
+
+    def test_a_later_year_picks_the_later_series(self, two_rebirths):
+        """Proximity, not a preference for the older row."""
+        from models.gcd import search_series
+        result = search_series("Batman Detective Comics Rebirth", year=2023)
+        assert result is not None
+        assert result["year_began"] == 2023
+
+    def test_without_a_year_the_newest_still_wins(self, two_rebirths):
+        """No year to be close to -- the existing recency order is unchanged."""
+        from models.gcd import search_series
+        result = search_series("Batman Detective Comics Rebirth")
+        assert result is not None
+        assert result["year_began"] == 2023
+
+    def test_a_year_outside_every_run_still_matches(self, two_rebirths):
+        """The point of leaving `tokenized` unfiltered: a reprint year still lands.
+
+        1985 predates both series, so a year *constraint* would return nothing.
+        Ranking only decides which one wins.
+        """
+        from models.gcd import search_series
+        result = search_series("Batman Detective Comics Rebirth", year=1985)
+        assert result is not None
+        assert result["year_began"] == 2018
+
+    def test_a_null_year_began_does_not_win_on_proximity(self, tmp_path, monkeypatch):
+        """ABS(NULL - y) is NULL and SQLite sorts NULLs first on ASC."""
+        from models.gcd import search_series
+        path = build_gcd_sqlite(tmp_path / "nullyear.db")
+        conn = sqlite3.connect(path)
+        conn.executemany(
+            "INSERT INTO gcd_series (id, name, year_began, year_ended, "
+            "publisher_id, language_id) VALUES (?, ?, ?, ?, ?, ?)",
+            [(410, "Batman: Detective Comics - Rebirth", 2018, None, 10, 1),
+             (411, "Detective Comics: Batman Rebirth Undated", None, None, 10, 1)],
+        )
+        conn.commit()
+        conn.close()
+        monkeypatch.setattr("models.gcd._get_saved_credentials",
+                            lambda: {"database_path": str(path)})
+        result = search_series("Batman Detective Comics Rebirth", year=2018)
+        assert result is not None
+        assert result["year_began"] == 2018
+
+
 class TestMainWordTokenTooBroad:
     """The probe helper is shared with routes/metadata.py, so test it directly."""
 

--- a/tests/routes/test_metadata_routes.py
+++ b/tests/routes/test_metadata_routes.py
@@ -1246,6 +1246,86 @@ class TestGcdSqliteRoutes:
         assert resp.get_json()['success'] is False
 
 
+class TestGcdSearchVariationParity:
+    """/search-gcd-metadata must apply the same variation policy as models.gcd.
+
+    This route reimplements the progressive-search loop rather than calling
+    search_series, so the year constraint and the one-token breadth guard have
+    to be shared explicitly. They used to be a hard-coded literal list and
+    nothing at all, which is why the same wrong-series match survived here after
+    the automatic path was fixed.
+    """
+
+    def _configure_gcd(self, tmp_path, monkeypatch):
+        from tests.mocked.conftest import build_gcd_sqlite
+        path = build_gcd_sqlite(tmp_path / "gcd.db")
+        monkeypatch.setattr("models.gcd._get_saved_credentials",
+                            lambda: {"database_path": str(path)})
+        return path
+
+    def _search(self, client, tmp_path, file_name):
+        cbz = tmp_path / file_name
+        _make_cbz(str(cbz), with_comicinfo=False)
+        with patch("routes.metadata.add_comicinfo_to_cbz", return_value=True),              patch("core.database.set_has_comicinfo"):
+            return client.post('/search-gcd-metadata', json={
+                'file_path': str(cbz), 'file_name': file_name,
+            })
+
+    def test_main_with_year_is_year_constrained(self, client, tmp_path, monkeypatch):
+        """Batman began in 1940, so a 1930 file must not fall back onto it.
+
+        Only `main_with_year` can reach the series here -- the parsed name is
+        not a substring of it and `tokenized` needs every token present -- so a
+        match proves the year was never applied.
+        """
+        self._configure_gcd(tmp_path, monkeypatch)
+        resp = self._search(client, tmp_path,
+                            "Batman Adventures Special Edition 001 (1930).cbz")
+        # Not a hard 404: the route hands the decision to the user instead of
+        # auto-tagging. What matters is that nothing was written.
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data['success'] is False
+        assert data['requires_selection'] is True
+        assert 'metadata' not in data
+
+    def test_main_with_year_still_matches_inside_the_run(self, client, tmp_path,
+                                                          monkeypatch):
+        """The constraint must not make the fallback useless -- 1975 is in range."""
+        self._configure_gcd(tmp_path, monkeypatch)
+        resp = self._search(client, tmp_path,
+                            "Batman Adventures Special Edition 001 (1975).cbz")
+        assert resp.status_code == 200
+        assert resp.get_json().get('metadata', {}).get('series') == 'Batman'
+
+    def test_over_broad_main_word_is_declined(self, client, tmp_path, monkeypatch):
+        """Past the cap the first row is an arbitrary pick, not a match.
+
+        Simulated by lowering the cap rather than loading thousands of series.
+        The route has no LIMIT on its query, so without this guard the whole
+        slice ('%le%' is 18,526 series in the real dump) is ranked by year and
+        serialised into possible_matches.
+        """
+        self._configure_gcd(tmp_path, monkeypatch)
+        monkeypatch.setattr("models.gcd.MAIN_WORD_MAX_CANDIDATES", 0)
+        resp = self._search(client, tmp_path,
+                            "Batman Adventures Special Edition 001.cbz")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data['success'] is False
+        assert data['requires_selection'] is True
+        assert 'metadata' not in data
+
+    def test_the_cap_does_not_apply_to_the_precise_variations(self, client, tmp_path,
+                                                              monkeypatch):
+        """An exact hit must survive a cap of zero -- only the fallback is guarded."""
+        self._configure_gcd(tmp_path, monkeypatch)
+        monkeypatch.setattr("models.gcd.MAIN_WORD_MAX_CANDIDATES", 0)
+        resp = self._search(client, tmp_path, "Batman 001.cbz")
+        assert resp.status_code == 200
+        assert resp.get_json().get('metadata', {}).get('series') == 'Batman'
+
+
 class TestComicVineSqliteRoutes:
     """End-to-end coverage of comicvine_sqlite through the /api/search-metadata cascade.
 

--- a/tests/routes/test_metadata_routes.py
+++ b/tests/routes/test_metadata_routes.py
@@ -1325,6 +1325,34 @@ class TestGcdSearchVariationParity:
         assert resp.status_code == 200
         assert resp.get_json().get('metadata', {}).get('series') == 'Batman'
 
+    def test_tokenized_hits_are_ordered_by_year_proximity(self, client, tmp_path,
+                                                          monkeypatch):
+        """The selection list must lead with the closest era, not the newest.
+
+        Two series contain every token and neither contains the parsed title as
+        a substring, so `tokenized` is the deciding tier. Ordering by recency
+        put the 2023 collected edition above the 2018 series the file is from.
+        """
+        import sqlite3
+        path = self._configure_gcd(tmp_path, monkeypatch)
+        conn = sqlite3.connect(str(path))
+        conn.executemany(
+            "INSERT INTO gcd_series (id, name, year_began, year_ended, "
+            "publisher_id, language_id) VALUES (?, ?, ?, ?, ?, ?)",
+            [(400, "Batman: Detective Comics - Rebirth", 2018, None, 10, 1),
+             (401, "Detective Comics: Batman Rebirth Deluxe", 2023, None, 10, 1)],
+        )
+        conn.commit()
+        conn.close()
+
+        resp = self._search(client, tmp_path,
+                            "Batman Detective Comics Rebirth 001 (2018).cbz")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data['requires_selection'] is True
+        assert data['search_method'] == 'tokenized'
+        assert data['possible_matches'][0]['year_began'] == 2018
+
 
 class TestComicVineSqliteRoutes:
     """End-to-end coverage of comicvine_sqlite through the /api/search-metadata cascade.


### PR DESCRIPTION
## 📝 Description

Follow-up to #518. Two of that PR's three fixes landed on `models/gcd.py` only, but
`routes/metadata.py` reimplements the same progressive-search loop — so the wrong-series
match it fixed survived on the interactive path. This brings the second loop to parity,
and resolves the one gap #518 opened rather than closed.

One commit each.

### 1. Parity for the second search loop (`8a85030`)

`search_gcd_metadata` (`/search-gcd-metadata`) runs its own copy of the variation loop.
It shares `generate_search_variations`, so #518's word-boundary fix propagated for free —
the other two did not:

- Its year-constrained branch tested a hard-coded `["exact", "no_issue", "no_year", "no_dash"]`.
  `main_with_year` fell through to the plain LIKE and the year was never applied, which is
  exactly the omission `YEAR_CONSTRAINED_VARIATIONS` was named to make visible. It now reads
  that constant.
- It had no breadth guard, and its query carries **no LIMIT** — so an over-broad one-token
  pattern (`%le%` is 18,526 series in the current dump) was ranked by year and serialised
  whole into `possible_matches`.

The route auto-selects when a search returns exactly one row, so a single wrong-era hit was
written to the file without asking. With the guard in place those fall through to the
selection modal instead — the failure mode changes from *silently tagged wrong* to *ask the
user*, which is the outcome you want when the evidence is this thin.

The probe moves out of `search_series` into `models.gcd.main_word_token_too_broad()` so the
two loops share one policy rather than two copies of the SQL — the shape `has_trusted_notes()`
already uses for the Notes sentinel. It handles an empty language list as `IN (NULL)`,
matching both callers' own convention.

Also pins the candidate cap's boundary. The tests added in #518 used caps of 0, 2 and 5
against 1 or 3 rows, so flipping `>` to `>=` passed all of them.

### 2. `tokenized` ranked by year proximity (`8d3aa4f`)

#518 made `tokenized` fire for the first time. That left it the only tier taking no account
of a year the filename supplied: it returned the first row of `ORDER BY year_began DESC`, so
where several series contain every token, the newest won over the right era — a 2018 file
matching a 2023 collected edition of its own run.

> **Why this is ranked and not filtered.** The obvious fix — give the REGEXP branch the same
> year clause the four LIKE variations use — is the wrong one. `tokenized` is the one tier
> that still matches when the filename's year falls *outside* the series' GCD run (a reprint
> year, a collected edition, a mis-parsed year), and that is precisely when every variation
> above it has already failed for the same reason. Filtering would remove the safety valve
> in the only case it exists for. Ranking by distance from the parsed year can only change
> which of several all-token matches wins — it can never drop one.

`COALESCE(s.year_began, 9999)` is load-bearing, not defensive: `ABS(NULL - y)` is NULL and
SQLite sorts NULLs **first** on ASC, so without it an undated series would outrank every real
candidate. There is a test for that specifically.

## 🛠️ Changes Made
- [x] Added new feature logic — `models/gcd.py`: new shared `main_word_token_too_broad()`,
      `proximity_suffix`; `routes/metadata.py`: guard + `YEAR_CONSTRAINED_VARIATIONS` +
      `regexp_query_by_year_proximity`
- [x] Updated Docker/Config if necessary — not needed, no new settings
- [x] No new dependencies

## 🧪 Testing Performed
- [x] Linting/Unit tests pass — **4310 passed, 7 skipped**, full suite, clean run

Every new test was checked to **fail on the pre-fix code**, not merely pass on the new:

- reverting `routes/metadata.py` fails 3 of the 5 new route tests
- reverting `models/gcd.py` fails 2 of the 5 new proximity tests, with the log line showing
  the old behaviour verbatim: `Found 'Detective Comics: Batman Rebirth Deluxe' (2023) using tokenized`

New tests: `tests/routes/test_metadata_routes.py::TestGcdSearchVariationParity` (5) covering
the year constraint on the route's `main_with_year`, the breadth guard declining rather than
auto-selecting, the cap not touching the precise variations, and the selection list leading
with the closest era; `tests/mocked/test_gcd_model.py` (11) covering proximity ranking in both
directions, recency preserved when no year is parsed, a year outside every run still matching,
the NULL `year_began` case, the cap boundary from both sides, and the shared probe helper
directly (including its language filter and the empty-language-list path).

## Not in this PR

`routes/metadata.py:2069` — the `alternative_matches` fallback that builds the selection list
when every variation misses — runs its own unguarded, unlimited `%word%` search for each word
longer than three characters. It is much narrower than the one-token fallback and only builds
a list rather than auto-tagging, but it can still return thousands of rows on a common word.
Pre-existing, and not something the guard here touches. Happy to bound it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
