### PR TITLE
Add a Back to top button to the Browse Library pager

### DIFF
--- a/static/css/collection.css
+++ b/static/css/collection.css
@@ -350,6 +350,16 @@ body.collection-select-mode {
     flex: 0 0 auto;
 }
 
+/* Back-to-top button: never shrink it away when a long readout competes for the row,
+   and keep it square so it reads as an icon control next to the Jump-to group. */
+#pagination-controls .pager-top {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 2rem;
+}
+
 /* Full body colour, not --bs-secondary-color: any mix toward the background can
    only lose contrast, and several themes (minty, morph, quartz, spacelab) start
    muted enough that the result fell to 1.8-2.8:1. Hierarchy comes from the
@@ -381,7 +391,8 @@ body.collection-select-mode {
 }
 
 @media (pointer: coarse) {
-    #pagination-controls .page-link {
+    #pagination-controls .page-link,
+    #pagination-controls .pager-top {
         min-width: 2.75rem;
         min-height: 2.75rem;
         display: flex;

--- a/static/js/collection.js
+++ b/static/js/collection.js
@@ -2463,6 +2463,18 @@ function scrollGridToTop() {
 }
 
 /**
+ * Jump the viewport back to the very top of the page (pager "Back to top" button).
+ * Unlike scrollGridToTop() this clears the folder header and breadcrumb too, and it
+ * animates: this one is a deliberate user action, not a side effect of paging, so the
+ * movement is what tells them the page didn't reload. Honours reduced-motion.
+ */
+function scrollPageToTop() {
+    const reduce = window.matchMedia
+        && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    window.scrollTo({ top: 0, behavior: reduce ? 'auto' : 'smooth' });
+}
+
+/**
  * Change the current page.
  * @param {number} page - The page number to switch to.
  */

--- a/templates/collection.html
+++ b/templates/collection.html
@@ -158,10 +158,20 @@
                        +/- 2, so a long library has no way to reach the middle. Options are
                        filled in by renderPagination(), which is also what makes an
                        out-of-range page unreachable -- there is nothing to type. #}
-                    <div class="pager-jump input-group input-group-sm d-none d-md-flex">
-                        <label class="input-group-text" for="pageJumpSelect">Jump to</label>
-                        <select class="form-select" id="pageJumpSelect" aria-label="Jump to page"
-                            onchange="jumpToPage(this.value)"></select>
+                    <div class="pager-tail d-flex align-items-center gap-2">
+                        <div class="pager-jump input-group input-group-sm d-none d-md-flex">
+                            <label class="input-group-text" for="pageJumpSelect">Jump to</label>
+                            <select class="form-select" id="pageJumpSelect" aria-label="Jump to page"
+                                onchange="jumpToPage(this.value)"></select>
+                        </div>
+                        {# Back to top: the pager is pinned to the bottom of a viewport that
+                           may be hundreds of tiles below the folder header, so this is the
+                           only way back up without scrolling the whole grid by hand. #}
+                        <button type="button" class="btn btn-sm btn-outline-secondary pager-top"
+                            id="pagerScrollTop" onclick="scrollPageToTop()"
+                            title="Back to top" aria-label="Scroll back to top">
+                            <i class="bi bi-arrow-up" aria-hidden="true"></i>
+                        </button>
                     </div>
                 </div>
             </nav>


### PR DESCRIPTION
## Problem

`#pagination-controls` is sticky to the bottom of the viewport, so on a full page of tiles the folder header and breadcrumb sit hundreds of pixels above the fold with no way back other than scrolling the grid by hand.

## Change

An icon button (`bi-arrow-up`) next to the Jump-to select, wrapped with it in a new `.pager-tail` flex group.

- `templates/collection.html` — the button, with `title`/`aria-label` since it is icon-only. It stays visible on mobile, where the Jump-to group is `d-none d-md-flex`.
- `static/js/collection.js` — `scrollPageToTop()` scrolls the window to 0 (so the header returns), animated unless `prefers-reduced-motion`. Deliberately distinct from the existing `scrollGridToTop()`, which stays instant because it fires as a side effect of paging.
- `static/css/collection.css` — keeps the button from shrinking when a long readout competes for the row, and adds it to the existing `(pointer: coarse)` 2.75rem touch-target rule alongside `.page-link`.

## Testing

`pytest` — 4310 passed, 7 skipped (the usual POSIX/symlink skips on Windows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
