### PR TITLE
Add a per-series "Check for Missing Issues" button

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ gunicorn -w 1 --threads 8 -b 0.0.0.0:5577 --timeout 120 app:app
 ### Routes
 | Module | Purpose |
 |--------|---------|
-| `routes/downloads.py` | GetComics search/download (search is scored server-side via `score_getcomics_result`), auto-download schedules, weekly packs |
+| `routes/downloads.py` | GetComics search/download (search is scored server-side via `score_getcomics_result`), auto-download schedules, weekly packs. `/api/series/<id>/check-missing` runs the scheduled sweep's own pass (`app.scheduled_getcomics_download`) against a single series — see **Scoped missing-issue checks** below |
 | `routes/files.py` | File ops — rename, delete, move, crop, combine CBZ, upload, cleanup |
 | `routes/collection.py` | File browsing — directory listing, search, thumbnails, metadata browse |
 | `routes/metadata.py` | ComicInfo.xml management — provider search, batch processing, field updates |
@@ -121,6 +121,31 @@ tests/
 - `metadata_bp` (routes/metadata.py): Metadata management
 - `series_bp` (routes/series.py): Series and releases
 - `notifications_bp` (routes/notifications.py): Apprise notification settings
+
+### Scoped Missing-Issue Checks
+
+`app.scheduled_getcomics_download` is one body serving two callers: the nightly
+sweep, and the "Check for Missing Issues" button on a series page
+(`only_series_id=<id>`). The scoped run differs in three ways, all asserted in
+`tests/unit/test_series_scoped_getcomics_run.py` because app.py cannot be
+imported in tests:
+
+- It narrows `mapped_series` to the one id.
+- It **ignores the series' Monitor toggle.** That toggle exists to keep the
+  *unattended* sweep off a series; clicking the button is an explicit request.
+- It **must not call `update_last_getcomics_run()`** — that stamp belongs to the
+  schedule, and moving it would make the nightly sweep look as though it had
+  already run.
+
+The scope parameter is `only_series_id`, not `series_id`, because the per-series
+loop rebinds `series_id` to the series it is processing — a parameter of that
+name is shadowed at the first iteration and the scoping silently lost.
+
+Progress goes through the operations registry (`core/app_state.py`), so the run
+shows up in the header indicator like any other background job. Pages that
+follow an operation they started poll **`/api/operation/<op_id>`**, never
+`/api/operations`: the latter *clears* the pending notification queue as a side
+effect, so it can only ever have the one poller in `base.html`.
 
 ### Notification Hook Sites
 

--- a/app.py
+++ b/app.py
@@ -978,7 +978,7 @@ def configure_sync_schedule():
 
 
 # Function to perform scheduled GetComics auto-download
-def scheduled_getcomics_download(dry_run=False):
+def scheduled_getcomics_download(dry_run=False, only_series_id=None, op_id=None):
     """Auto-download wanted issues from GetComics on schedule.
 
     Args:
@@ -986,6 +986,21 @@ def scheduled_getcomics_download(dry_run=False):
                  actual downloads. Returns a list of simulation results instead
                  of queuing downloads. Each result contains search params,
                  all results, and the best match found.
+        only_series_id: Restrict the run to a single mapped series -- the
+                 "Check for Missing Issues" button on a series page. That is an
+                 explicit, user-initiated search, so it also ignores the series'
+                 Monitor toggle (which exists to keep the *unattended* sweep off
+                 a series) and leaves the schedule's last-run stamp alone.
+                 Named ``only_series_id`` rather than ``series_id`` because the
+                 per-series loop below binds ``series_id`` to the series it is
+                 currently processing.
+        op_id: Operations-registry id (core/app_state) to report progress
+                 against. The caller registers it so it can hand the id to the
+                 browser immediately; this function updates and completes it.
+
+    Returns:
+        ``{"searched": int, "queued": int}``, or the simulation list when
+        ``dry_run`` is set.
     """
     try:
         from core.database import (
@@ -1009,12 +1024,20 @@ def scheduled_getcomics_download(dry_run=False):
 
         simulation_results = [] if dry_run else None
 
+        def _progress(current=None, total=None, detail=None):
+            """Report to the operations registry; no-op for unwatched runs."""
+            if op_id:
+                app_state.update_operation(
+                    op_id, current=current, total=total, detail=detail
+                )
+
         app_logger.info("Starting scheduled GetComics auto-download...")
         start_time = time.time()
 
         today = date.today().isoformat()
         download_count = 0
         search_count = 0
+        wanted_total = 0  # denominator for _progress, grown per series
 
         # External source wiring (Usenet, DC++). Each enabled+configured source
         # either precedes GetComics (tried first, skipping GetComics on a hit)
@@ -1025,6 +1048,11 @@ def scheduled_getcomics_download(dry_run=False):
 
         # Get all mapped series
         mapped_series = get_all_mapped_series()
+
+        # Scoped run: one series, triggered by hand from its page. An unmapped
+        # or unknown id yields an empty list, so the run is a no-op.
+        if only_series_id is not None:
+            mapped_series = [s for s in mapped_series if s.get("id") == only_series_id]
 
         # Track downloaded ranges per series to avoid re-downloading the same range
         # Format: {series_name: [(start_issue, end_issue), ...]}
@@ -1039,7 +1067,9 @@ def scheduled_getcomics_download(dry_run=False):
             publisher_name = series.get("publisher_name")
 
             # Skip series the user isn't monitoring (NULL on legacy rows => on).
-            if series.get("monitored") == 0:
+            # A scoped run is an explicit request for this one series, so the
+            # toggle -- which only governs the unattended sweep -- doesn't apply.
+            if only_series_id is None and series.get("monitored") == 0:
                 continue
 
             if not mapped_path or not os.path.exists(mapped_path):
@@ -1068,6 +1098,18 @@ def scheduled_getcomics_download(dry_run=False):
 
             # Get manual status for this series (owned/skipped)
             manual_status = get_manual_status_for_series(series_id)
+
+            # Count what this series contributes before any (slow, networked)
+            # search runs, so the progress bar has a denominator from the start.
+            wanted_total += sum(
+                1
+                for i in issues
+                if not issue_status.get(str(i.get("number", "")), {}).get("found")
+                and str(i.get("number", "")) not in manual_status
+                and i.get("store_date")
+                and i.get("store_date") <= today
+            )
+            _progress(total=wanted_total)
 
             # Find wanted issues with store_date <= today (already released)
             for issue in issues:
@@ -1106,6 +1148,10 @@ def scheduled_getcomics_download(dry_run=False):
                         continue
 
                     # Search GetComics for this issue
+                    _progress(
+                        current=search_count,
+                        detail=f"{series_name} #{issue_num}",
+                    )
                     search_count += 1
 
                     # Get year from store_date or series (used in query and scoring)
@@ -1500,21 +1546,36 @@ def scheduled_getcomics_download(dry_run=False):
                     )
                     continue
 
-        # Update last run timestamp
-        update_last_getcomics_run()
+        # Update last run timestamp -- the *schedule's*, so a scoped run
+        # (one series, on demand) must not move it.
+        if only_series_id is None:
+            update_last_getcomics_run()
 
         elapsed = time.time() - start_time
         app_logger.info(
             f"GetComics auto-download completed in {elapsed:.2f}s ({search_count} searched, {download_count} queued)"
         )
 
+        if op_id:
+            app_state.update_operation(
+                op_id,
+                current=search_count,
+                detail=f"{search_count} searched, {download_count} queued",
+            )
+            app_state.complete_operation(op_id)
+
         if dry_run:
             return simulation_results
+        return {"searched": search_count, "queued": download_count}
 
     except Exception as e:
         app_logger.error(f"GetComics auto-download failed: {e}")
+        if op_id:
+            app_state.update_operation(op_id, detail=f"Failed: {e}")
+            app_state.complete_operation(op_id, error=True)
         if dry_run:
             return []
+        return {"searched": 0, "queued": 0, "error": str(e)}
 
 
 def configure_getcomics_schedule():

--- a/routes/downloads.py
+++ b/routes/downloads.py
@@ -8,6 +8,7 @@ Provides routes for:
 - Weekly packs configuration, history, and status
 """
 
+import os
 import uuid
 import threading
 import time
@@ -764,6 +765,90 @@ def api_run_getcomics_now():
         })
     except Exception as e:
         app_logger.error(f"Failed to start getcomics download: {e}")
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
+@downloads_bp.route('/api/series/<int:series_id>/check-missing', methods=['POST'])
+def api_check_series_missing(series_id):
+    """Search the configured sources for one series' missing issues.
+
+    The same search/score/queue pass the scheduled sweep runs
+    (``app.scheduled_getcomics_download``), narrowed to a single series -- the
+    "Check for Missing Issues" button on that series' page. It runs on a
+    background thread because a series with a dozen wanted issues makes a dozen
+    networked searches and would outlive gunicorn's request timeout, and it
+    reports through the operations registry so the header indicator (and the
+    caller, via ``op_id``) can follow it.
+    """
+    try:
+        from app import scheduled_getcomics_download
+
+        series = get_series_by_id(series_id)
+        if not series:
+            return jsonify({"success": False, "error": "Series not found"}), 404
+
+        mapped_path = (series.get("mapped_path") or "").strip()
+        if not mapped_path:
+            return jsonify({
+                "success": False,
+                "error": "Map this series to a collection folder first",
+            }), 400
+        # The sweep skips a series whose folder is gone, which would look like a
+        # run that found nothing. Say so instead.
+        if not os.path.isdir(mapped_path):
+            return jsonify({
+                "success": False,
+                "error": f"Mapped folder not found: {mapped_path}",
+            }), 400
+
+        series_name = series.get("name") or f"Series {series_id}"
+        op_id = app_state.register_operation("search", f"Checking {series_name}")
+
+        threading.Thread(
+            target=scheduled_getcomics_download,
+            kwargs={"only_series_id": series_id, "op_id": op_id},
+            daemon=True,
+        ).start()
+
+        app_logger.info(f"Missing-issue check started for {series_name} ({series_id})")
+        return jsonify({
+            "success": True,
+            "op_id": op_id,
+            "message": f"Searching for missing issues in {series_name}",
+        })
+    except Exception as e:
+        app_logger.error(f"Failed to check missing issues for series {series_id}: {e}")
+        return jsonify({"success": False, "error": str(e)}), 500
+
+
+@downloads_bp.route('/api/operation/<op_id>', methods=['GET'])
+def api_operation_status(op_id):
+    """Status of a single background operation.
+
+    Deliberately separate from ``/api/operations`` (app.py): that endpoint
+    *clears* queued notifications as a side effect, so it can only be polled by
+    the one poller in base.html -- a second poller would swallow toasts meant
+    for the header. Pages that follow an operation they started poll this one.
+
+    A completed operation is pruned from the registry after a short TTL, so an
+    absent operation means finished, not failed.
+    """
+    try:
+        from flask import g
+        from core.auth import is_login_required
+
+        user = getattr(g, "current_user", None)
+        if not is_login_required() or (user and user.get("role") == "owner"):
+            ops = app_state.get_active_operations()
+        else:
+            ops = app_state.get_active_operations(
+                viewer_id=user["id"] if user else None
+            )
+
+        op = next((o for o in ops if o.get("id") == op_id), None)
+        return jsonify({"success": True, "operation": op})
+    except Exception as e:
+        app_logger.error(f"Failed to read operation {op_id}: {e}")
         return jsonify({"success": False, "error": str(e)}), 500
 
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -196,7 +196,7 @@
             return b.started_at - a.started_at;
           });
 
-          const iconMap = { metadata: 'bi-tags', move: 'bi-arrows-move', convert: 'bi-arrow-repeat', rebuild: 'bi-hammer', import: 'bi-cloud-upload', upload: 'bi-cloud-arrow-up', match: 'bi-collection', repair: 'bi-wrench-adjustable', rename: 'bi-input-cursor-text', credit_backfill: 'bi-person-badge' };
+          const iconMap = { metadata: 'bi-tags', move: 'bi-arrows-move', convert: 'bi-arrow-repeat', rebuild: 'bi-hammer', import: 'bi-cloud-upload', upload: 'bi-cloud-arrow-up', match: 'bi-collection', repair: 'bi-wrench-adjustable', rename: 'bi-input-cursor-text', credit_backfill: 'bi-person-badge', search: 'bi-search' };
           let html = '';
           ops.forEach(op => {
             const icon = iconMap[op.op_type] || 'bi-gear';

--- a/templates/series.html
+++ b/templates/series.html
@@ -202,6 +202,11 @@
                     {% if mapped_path %}
                     <hr class="my-2">
                     <div class="d-flex justify-content-end gap-3">
+                        <button class="btn btn-outline-primary btn-sm" onclick="checkForMissing()"
+                            id="checkMissingBtn"
+                            title="Search the configured sources for this series' missing issues">
+                            <i class="bi bi-search me-1"></i>Check for Missing Issues
+                        </button>
                         <button class="btn btn-outline-secondary btn-sm" onclick="syncSeries()" id="sync-btn"
                             title="Check API for New Issues">
                             <i class="bi bi-arrow-repeat me-1"></i>API Sync
@@ -1028,6 +1033,81 @@
             document.getElementById('monitorSeries').checked = !enabled;
             showToast('Failed to update monitoring', 'danger');
         }
+    }
+
+    // Search the configured sources (GetComics/Usenet/DC++) for the issues this
+    // series is missing. The Wanted page has a button of the same name that runs
+    // the identical pass across every monitored series; this one is scoped to
+    // this series and ignores its Monitor toggle, since clicking it is an
+    // explicit request.
+    const CHECK_MISSING_LABEL = '<i class="bi bi-search me-1"></i>Check for Missing Issues';
+    let missingCheckPoll = null;
+
+    function checkForMissing() {
+        const btn = document.getElementById('checkMissingBtn');
+        if (!btn) return;
+        btn.disabled = true;
+        btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1"></span>Checking...';
+
+        fetch('/api/series/{{ series.id }}/check-missing', { method: 'POST' })
+            .then(r => r.json())
+            .then(data => {
+                if (!data.success) {
+                    resetCheckMissingBtn();
+                    showToastGC('Error: ' + (data.error || 'Check failed'), 'danger');
+                    return;
+                }
+                showToastGC(data.message, 'info');
+                pollMissingCheck(data.op_id);
+            })
+            .catch(e => {
+                resetCheckMissingBtn();
+                showToastGC('Error: ' + e.message, 'danger');
+            });
+    }
+
+    function resetCheckMissingBtn() {
+        const btn = document.getElementById('checkMissingBtn');
+        if (!btn) return;
+        btn.disabled = false;
+        btn.title = "Search the configured sources for this series' missing issues";
+        btn.innerHTML = CHECK_MISSING_LABEL;
+    }
+
+    // Follow the background run. Polls /api/operation/<id> and NOT
+    // /api/operations — that one clears the notification queue base.html's
+    // poller owns, so a second poller would swallow its toasts. A finished
+    // operation is pruned from the registry after a short TTL, so an absent
+    // operation means done, not failed.
+    function pollMissingCheck(opId) {
+        if (!opId) {
+            resetCheckMissingBtn();
+            return;
+        }
+        if (missingCheckPoll) clearInterval(missingCheckPoll);
+        missingCheckPoll = CLU.startPoll(signal =>
+            fetch(`/api/operation/${encodeURIComponent(opId)}`, { signal })
+                .then(r => r.json())
+                .then(data => {
+                    const op = data.operation;
+                    if (op && op.status === 'running') {
+                        const btn = document.getElementById('checkMissingBtn');
+                        if (btn && op.detail) btn.title = op.detail;
+                        return;
+                    }
+                    clearInterval(missingCheckPoll);
+                    missingCheckPoll = null;
+                    resetCheckMissingBtn();
+                    if (op && op.status === 'error') {
+                        showToastGC('Check failed: ' + (op.detail || 'unknown error'), 'danger');
+                    } else {
+                        showToastGC(
+                            'Missing issue check complete' +
+                            (op && op.detail ? ' — ' + op.detail : ''),
+                            'success'
+                        );
+                    }
+                }), 2000);
     }
 
     function updateSubscribePath() {

--- a/tests/routes/test_downloads_routes.py
+++ b/tests/routes/test_downloads_routes.py
@@ -273,6 +273,95 @@ class TestRunGetcomicsNow:
         assert resp.get_json()["success"] is True
 
 
+class TestCheckSeriesMissing:
+    """POST /api/series/<id>/check-missing — the series page's own
+    "Check for Missing Issues" button. Same search pass as the scheduled sweep,
+    narrowed to one series."""
+
+    MAPPED = {"id": 100, "name": "Batman", "mapped_path": "/data/DC Comics/Batman"}
+
+    def test_unknown_series_404(self, client):
+        with patch("routes.downloads.get_series_by_id", return_value=None):
+            resp = client.post("/api/series/999/check-missing")
+        assert resp.status_code == 404
+        assert resp.get_json()["success"] is False
+
+    def test_unmapped_series_400(self, client):
+        series = {"id": 100, "name": "Batman", "mapped_path": ""}
+        with patch("routes.downloads.get_series_by_id", return_value=series):
+            resp = client.post("/api/series/100/check-missing")
+        assert resp.status_code == 400
+        assert "Map this series" in resp.get_json()["error"]
+
+    def test_missing_folder_400(self, client):
+        """A vanished folder is reported, not silently searched to no effect."""
+        with patch("routes.downloads.get_series_by_id", return_value=self.MAPPED),                 patch("routes.downloads.os.path.isdir", return_value=False):
+            resp = client.post("/api/series/100/check-missing")
+        assert resp.status_code == 400
+        assert "not found" in resp.get_json()["error"]
+
+    def test_starts_a_scoped_background_run(self, client):
+        mock_app = MagicMock()
+        with patch.dict("sys.modules", {"app": mock_app}),                 patch("routes.downloads.get_series_by_id", return_value=self.MAPPED),                 patch("routes.downloads.os.path.isdir", return_value=True),                 patch("routes.downloads.threading") as mock_threading:
+            resp = client.post("/api/series/100/check-missing")
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["op_id"]
+
+        kwargs = mock_threading.Thread.call_args.kwargs
+        # Scoped to this series, and reporting against the op the caller polls.
+        assert kwargs["kwargs"] == {"only_series_id": 100, "op_id": data["op_id"]}
+        assert kwargs["daemon"] is True
+        mock_threading.Thread.return_value.start.assert_called_once()
+
+    def test_registers_a_trackable_operation(self, client):
+        import core.app_state as app_state
+
+        with patch.dict("sys.modules", {"app": MagicMock()}),                 patch("routes.downloads.get_series_by_id", return_value=self.MAPPED),                 patch("routes.downloads.os.path.isdir", return_value=True),                 patch("routes.downloads.threading"):
+            resp = client.post("/api/series/100/check-missing")
+
+        op_id = resp.get_json()["op_id"]
+        op = next(
+            (o for o in app_state.get_active_operations() if o["id"] == op_id), None
+        )
+        assert op is not None
+        assert op["op_type"] == "search"
+        assert "Batman" in op["label"]
+        app_state.complete_operation(op_id)
+
+
+class TestOperationStatus:
+    """GET /api/operation/<id> — the single-operation read the series page
+    polls. Deliberately separate from /api/operations, which clears the
+    notification queue base.html's poller owns."""
+
+    def test_returns_a_running_operation(self, client):
+        import core.app_state as app_state
+
+        op_id = app_state.register_operation("search", "Checking Batman", total=3)
+        app_state.update_operation(op_id, current=1, detail="Batman #2")
+        try:
+            resp = client.get(f"/api/operation/{op_id}")
+        finally:
+            app_state.complete_operation(op_id)
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["operation"]["status"] == "running"
+        assert data["operation"]["detail"] == "Batman #2"
+
+    def test_unknown_operation_is_null_not_an_error(self, client):
+        """A finished op is pruned after a short TTL, so absent means done."""
+        resp = client.get("/api/operation/does-not-exist")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["operation"] is None
+
+
 class TestWeeklyPacksConfig:
 
     @patch("core.database.get_weekly_packs_config", return_value=None)

--- a/tests/unit/test_series_scoped_getcomics_run.py
+++ b/tests/unit/test_series_scoped_getcomics_run.py
@@ -1,0 +1,149 @@
+"""Invariants of the series-scoped GetComics run.
+
+``app.scheduled_getcomics_download(only_series_id=...)`` backs the "Check for
+Missing Issues" button on a series page. Three properties make the scoped run
+different from the unattended sweep, and all three are easy to undo by editing
+the shared body:
+
+* it narrows ``mapped_series`` to the requested id;
+* it ignores the series' Monitor toggle — that toggle exists to keep the
+  *unattended* sweep off a series, and a click is an explicit request;
+* it leaves the schedule's last-run stamp alone, so a one-series check can't
+  make the nightly sweep look as though it has already run.
+
+app.py cannot be imported in tests (importing it starts the scheduler and
+spawns monitor.py), so these are asserted against the parsed AST.
+"""
+
+import ast
+import os
+
+import pytest
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+APP_PATH = os.path.join(PROJECT_ROOT, "app.py")
+
+FUNC = "scheduled_getcomics_download"
+
+
+@pytest.fixture(scope="module")
+def func_node():
+    with open(APP_PATH, encoding="utf-8") as fh:
+        tree = ast.parse(fh.read())
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == FUNC:
+            return node
+    pytest.fail(f"{FUNC} not found in app.py")
+
+
+def _guards_on(func_node, name):
+    """Every ``if`` whose test mentions ``name``."""
+    out = []
+    for stmt in ast.walk(func_node):
+        if not isinstance(stmt, ast.If):
+            continue
+        if any(
+            isinstance(n, ast.Name) and n.id == name
+            for n in ast.walk(stmt.test)
+        ):
+            out.append(stmt)
+    return out
+
+
+def _calls_named(node, name):
+    return [
+        child for child in ast.walk(node)
+        if isinstance(child, ast.Call)
+        and isinstance(child.func, ast.Name)
+        and child.func.id == name
+    ]
+
+
+class TestScopedRunSignature:
+    def test_accepts_only_series_id_and_op_id(self, func_node):
+        args = [a.arg for a in func_node.args.args]
+        assert "only_series_id" in args
+        assert "op_id" in args
+
+    def test_scope_parameter_is_not_named_series_id(self, func_node):
+        # The per-series loop rebinds ``series_id`` to the series it is
+        # processing; a parameter of that name would be shadowed and the
+        # scoping silently lost.
+        assert "series_id" not in [a.arg for a in func_node.args.args]
+
+    def test_both_new_parameters_default_to_none(self, func_node):
+        args = func_node.args.args
+        defaults = dict(
+            zip([a.arg for a in args[-len(func_node.args.defaults):]],
+                func_node.args.defaults)
+        )
+        for name in ("only_series_id", "op_id"):
+            node = defaults[name]
+            assert isinstance(node, ast.Constant) and node.value is None
+
+
+class TestScopedRunBehaviour:
+    def test_mapped_series_is_narrowed_to_the_requested_id(self, func_node):
+        """A scoped run filters the mapped-series list before the loop."""
+        narrowing = [
+            stmt for stmt in _guards_on(func_node, "only_series_id")
+            if any(
+                isinstance(n, ast.Name) and n.id == "mapped_series"
+                for sub in stmt.body for n in ast.walk(sub)
+            )
+        ]
+        assert narrowing, "no `if only_series_id is not None:` narrowing mapped_series"
+
+    def test_monitor_toggle_is_bypassed_when_scoped(self, func_node):
+        """The `monitored == 0` skip must also require an unscoped run."""
+        monitored_guards = [
+            stmt for stmt in ast.walk(func_node)
+            if isinstance(stmt, ast.If)
+            and any(
+                isinstance(n, ast.Constant) and n.value == "monitored"
+                for n in ast.walk(stmt.test)
+            )
+        ]
+        assert monitored_guards, "the monitored skip disappeared from the sweep"
+        for stmt in monitored_guards:
+            names = {n.id for n in ast.walk(stmt.test) if isinstance(n, ast.Name)}
+            assert "only_series_id" in names, (
+                "the Monitor toggle would skip an explicitly requested series"
+            )
+
+    def test_last_run_stamp_is_only_written_by_an_unscoped_run(self, func_node):
+        calls = _calls_named(func_node, "update_last_getcomics_run")
+        assert len(calls) == 1, "expected exactly one last-run write"
+        guarded = [
+            stmt for stmt in _guards_on(func_node, "only_series_id")
+            if _calls_named(stmt, "update_last_getcomics_run")
+        ]
+        assert guarded, (
+            "update_last_getcomics_run() is not guarded by `only_series_id is None` — "
+            "a one-series check would move the schedule's last-run stamp"
+        )
+
+    def test_progress_is_reported_through_the_operations_registry(self, func_node):
+        """The op the route hands back must be updated and completed."""
+        attr_calls = {
+            child.func.attr for child in ast.walk(func_node)
+            if isinstance(child, ast.Call) and isinstance(child.func, ast.Attribute)
+        }
+        assert "update_operation" in attr_calls
+        assert "complete_operation" in attr_calls
+
+    def test_the_operation_is_completed_on_the_failure_path_too(self, func_node):
+        """An abandoned op would sit in the header indicator until it goes stale."""
+        handlers = [
+            h for h in ast.walk(func_node) if isinstance(h, ast.ExceptHandler)
+        ]
+        completing = [
+            h for h in handlers
+            if any(
+                isinstance(c, ast.Call)
+                and isinstance(c.func, ast.Attribute)
+                and c.func.attr == "complete_operation"
+                for c in ast.walk(h)
+            )
+        ]
+        assert completing, "no except handler completes the operation"


### PR DESCRIPTION
The Wanted page can already sweep every monitored series for the issues it is missing. This adds the same action to a single series' page, next to API Sync and Refresh.

<img width="600" alt="button placement: Check for Missing Issues, API Sync, Refresh, On the Stack, Monitor" src="" />

## Scoped runs

`app.scheduled_getcomics_download` is now one body serving two callers. A scoped run (`only_series_id=<id>`) differs from the nightly sweep in three ways:

- it narrows `mapped_series` to the one id;
- it **ignores that series' Monitor toggle** — the toggle exists to keep the *unattended* sweep off a series, and clicking the button is an explicit request;
- it leaves `update_last_getcomics_run()` alone, so a one-series check can't make the nightly sweep look as though it had already run.

The parameter is named `only_series_id` and not `series_id` because the per-series loop rebinds `series_id` to the series it is processing — a parameter of that name is shadowed on the first iteration and the scoping is silently lost.

Search, scoring and queuing are untouched, so the scorer and the dry-run simulator stay in step.

## Routes

- `POST /api/series/<id>/check-missing` — validates the series exists, is mapped, and that its folder is still there (a vanished folder otherwise looks like a run that found nothing), registers an operation, and runs the pass on a background thread. A series with a dozen wanted issues makes a dozen networked searches, well past gunicorn's 120s timeout.
- `GET /api/operation/<op_id>` — reads one operation. Deliberately separate from `/api/operations`, which *clears* the pending notification queue as a side effect and so can only ever have the one poller in `base.html`; a second poller there would swallow the header's toasts.

Both fall through `core/auth.py` to clerk, matching the rest of the download surface — no auth changes.

## UI

The button polls `/api/operation/<id>` through `CLU.startPoll`, surfaces the current issue on hover, and toasts the summary (`5 searched, 2 queued`) when the run ends. The header operations indicator tracks it too, under a new `search` → `bi-search` icon.

Rows don't flip to "found" on completion by design: the queued files still have to download and be imported first, so there is nothing new to show yet.

## Tests

- 7 route tests — unknown/unmapped/missing-folder rejections, scoped kwargs handed to the thread, the operation registered as trackable, and the single-operation read.
- 8 AST tests (`tests/unit/test_series_scoped_getcomics_run.py`) locking the three scoped-run rules above and the parameter name, since app.py cannot be imported in tests.

Full suite: **4432 passed, 7 skipped** (the known POSIX/symlink skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BYB2bF4mdCDQXB4wya4PfS
