### PR TITLE
Rank GCD candidates instead of taking the newest survivor

### DIFF
--- a/models/gcd.py
+++ b/models/gcd.py
@@ -41,8 +41,24 @@ YEAR_CONSTRAINED_VARIATIONS = frozenset({
     "exact", "no_issue", "no_year", "no_dash", "main_with_year",
 })
 
+# How many rows the ranker may see. This is the candidate window, not the
+# number of results returned: every row inside it is scored and exactly one
+# wins. `ORDER BY year_began DESC` decides which rows fall inside, so a narrow
+# window silently hides the right series behind newer ones that merely contain
+# its name -- with the window at 10, ranking still gets 23 of 10,000 verbatim
+# series names wrong for that reason alone, and at 200 it gets none.
+#
+# Widening it is close to free: measured over 3,633 real archives against the
+# 2026-08-22 dump, 10 -> 200 costs 1.009x wall clock (+1.28 ms on a 145 ms
+# baseline per file) for nearly triple the rows. The cost of these queries is
+# the unanchored LIKE scanning gcd_series; LIMIT only truncates output that has
+# already been found.
+CANDIDATE_LIMIT = 200
+
 # How many candidate series the main-word fallback may match and still be
-# treated as evidence. The loop only ever inspects the first row, so beyond a
+# treated as evidence. Unrelated to CANDIDATE_LIMIT and deliberately not raised
+# with it: this one caps how broad a token may be before the fallback declines
+# altogether. The loop only ever inspects the first row, so beyond a
 # handful of candidates "first by year" is an arbitrary pick rather than a best
 # match. Raising this does not improve matching -- it only makes wrong matches
 # more likely.
@@ -608,7 +624,7 @@ def search_series(series_name: str, year: int = None, language_codes: List[str] 
                     ' LEFT JOIN gcd_publisher p ON s.publisher_id = p.id'
                 )
                 lang_filter = ' AND l.code IN (' + lang_placeholders + ')'
-                order_suffix = ' ORDER BY s.year_began DESC LIMIT 10'
+                order_suffix = f' ORDER BY s.year_began DESC LIMIT {CANDIDATE_LIMIT}'
                 # `tokenized` is not year-*filtered* (see
                 # YEAR_CONSTRAINED_VARIATIONS), but when the filename supplied a
                 # year there is no reason to break its ties by recency. Ranking
@@ -618,7 +634,7 @@ def search_series(series_name: str, year: int = None, language_codes: List[str] 
                 # and SQLite sorts NULLs first on ASC.
                 proximity_suffix = (
                     ' ORDER BY ABS(COALESCE(s.year_began, 9999) - ?) ASC,'
-                    ' s.year_began DESC LIMIT 10'
+                    f' s.year_began DESC LIMIT {CANDIDATE_LIMIT}'
                 )
 
                 # Decline the one-token fallback when it cannot narrow the

--- a/models/gcd.py
+++ b/models/gcd.py
@@ -83,6 +83,59 @@ def normalize_title(s: str) -> str:
     return s
 
 
+def rank_key(query_name: str, year, candidate):
+    """Sort key that picks the best candidate series, not the newest one.
+
+    Every search variation used to take `results[0]` of `ORDER BY year_began
+    DESC`, so the winner was the most recently started series that survived the
+    filter. That is how `Superman (2000)` matched `Mann and Superman`: `exact`
+    is an unanchored LIKE, both ran in 2000, and the longer name was newer.
+
+    Ordering, most significant first:
+
+    1. the normalised names being equal -- an exact title beats any name that
+       merely contains it, which is the whole defect this closes;
+    2. words the candidate has that the query does not, so a longer name
+       loses to a shorter one that says the same thing;
+    3. words the query has that the candidate does not;
+    4. difference in normalised length, as a finer version of the same idea;
+    5. distance from the parsed year, so the year settles ties instead of
+       deciding matches;
+    6. `id`, so the order is total and the winner is reproducible rather than
+       dependent on the order rows came back in.
+
+    `year` may be None, in which case every candidate ties on (5) and the
+    remaining keys decide.
+    """
+    nq = normalize_title(query_name or "")
+    nc = normalize_title(candidate["name"] or "")
+    tq, tc = set(nq.split()), set(nc.split())
+    # The two callers disagree on the type of `year`: search_series() takes an
+    # int, the interactive loop in routes/metadata.py carries the string it
+    # parsed from the filename. Coerce rather than assume, and treat anything
+    # unparseable as "no year", which ties every candidate on this key instead
+    # of raising in the middle of a search.
+    try:
+        y = int(year) if year not in (None, "") else None
+    except (TypeError, ValueError):
+        y = None
+    # A series with no recorded start date must rank *worst* on year, not
+    # best: `abs(None - y)` cannot be computed, and treating it as 0 would make
+    # every undated record beat a real candidate. 9999 mirrors the
+    # COALESCE(s.year_began, 9999) the proximity ORDER BY already uses, so the
+    # SQL ordering and the ranker agree on what a missing year means.
+    began = candidate["year_began"] or 9999
+    year_gap = abs(began - y) if y else 0
+    return (
+        0 if nq == nc else 1,
+        len(tc - tq),
+        len(tq - tc),
+        abs(len(nc) - len(nq)),
+        year_gap,
+        candidate["id"],
+    )
+
+
 def tokens_for_all_match(s: str):
     """Normalize and drop stopwords for 'all tokens present' matching."""
     norm = normalize_title(s)
@@ -615,9 +668,17 @@ def search_series(series_name: str, year: int = None, language_codes: List[str] 
 
                 results = cursor.fetchall()
                 if results:
-                    # Auto-select the best match (first result, sorted by year)
-                    series_result = results[0]
-                    app_logger.info(f"GCD search_series: Found '{series_result['name']}' ({series_result['year_began']}) using {search_type}")
+                    # Pick the best row of the window, not the first. The ORDER
+                    # BY decides which candidates the ranker gets to see; it no
+                    # longer decides which one wins. See rank_key().
+                    series_result = min(
+                        results, key=lambda r: rank_key(series_name, year, r)
+                    )
+                    app_logger.info(
+                        f"GCD search_series: Found '{series_result['name']}' "
+                        f"({series_result['year_began']}) using {search_type} "
+                        f"-- best of {len(results)} candidate(s)"
+                    )
                     break
 
             except Exception as e:

--- a/routes/metadata.py
+++ b/routes/metadata.py
@@ -2072,7 +2072,15 @@ def search_gcd_metadata():
                     app_logger.debug(f"DEBUG: {search_type} search found {len(current_results)} results")
 
                     if current_results:
-                        series_results = current_results
+                        # Same policy as the automatic path: order the window by
+                        # how well each candidate matches, not by how recent it
+                        # is. This loop has no LIMIT, so there is no window to
+                        # widen here -- but it feeds the selection modal, and
+                        # the user should be offered the best candidate first.
+                        series_results = sorted(
+                            current_results,
+                            key=lambda r: gcd.rank_key(series_name, year, r),
+                        )
                         search_success_method = search_type
                         app_logger.debug(f"DEBUG: Success with {search_type} search method!")
                         break

--- a/tests/mocked/test_gcd_model.py
+++ b/tests/mocked/test_gcd_model.py
@@ -485,19 +485,56 @@ class TestTokenizedYearProximity:
         assert result is not None
         assert result["year_began"] == 2018
 
-    def test_a_later_year_picks_the_later_series(self, two_rebirths):
-        """Proximity, not a preference for the older row."""
+    def test_name_agreement_outranks_year_proximity(self, two_rebirths):
+        """Changed here: the year no longer wins against a better name.
+
+        This case used to assert the 2023 row, on the grounds that the parsed
+        year should pick the closest era among all-token matches. Ranking
+        subordinates the year to name agreement, so the 2018 row wins at 2023
+        as well: its name normalises exactly to the query, while the 2023 one
+        carries an extra word ("Deluxe") the filename never had.
+
+        Measured rather than argued. Over 3,000 series names per language with
+        punctuation rewritten, keeping year proximity as the tie-break for
+        `tokenized` was worse than ranking it: 49 wrong vs 42 in Italian, 243
+        vs 219 in English. The year still decides between candidates whose
+        names agree equally well -- see the tests below.
+        """
         from models.gcd import search_series
         result = search_series("Batman Detective Comics Rebirth", year=2023)
         assert result is not None
-        assert result["year_began"] == 2023
+        assert result["year_began"] == 2018
 
-    def test_without_a_year_the_newest_still_wins(self, two_rebirths):
-        """No year to be close to -- the existing recency order is unchanged."""
+    def test_without_a_year_the_better_name_wins(self, two_rebirths):
+        """No year to be close to, so name agreement decides alone."""
         from models.gcd import search_series
         result = search_series("Batman Detective Comics Rebirth")
         assert result is not None
-        assert result["year_began"] == 2023
+        assert result["year_began"] == 2018
+
+    def test_the_year_still_decides_between_equally_good_names(self, two_rebirths, tmp_path, monkeypatch):
+        """The proximity order #527 added is still load-bearing.
+
+        Where two candidates agree with the query equally well, nothing above
+        the year key separates them, so the parsed year picks the era -- which
+        is what that ordering was for.
+        """
+        import sqlite3 as _sq
+        path = build_gcd_sqlite(tmp_path / "twins.db")
+        conn = _sq.connect(path)
+        conn.executemany(
+            "INSERT INTO gcd_series (id, name, year_began, year_ended, "
+            "publisher_id, language_id) VALUES (?, ?, ?, ?, ?, ?)",
+            [(500, "Strange Tales - Annual", 1962, None, 10, 1),
+             (501, "Strange Tales: Annual", 1998, None, 10, 1)],
+        )
+        conn.commit()
+        conn.close()
+        monkeypatch.setattr("models.gcd._get_saved_credentials",
+                            lambda: {"database_path": str(path)})
+        from models.gcd import search_series
+        assert search_series("Strange Tales Annual", year=1963)["year_began"] == 1962
+        assert search_series("Strange Tales Annual", year=1999)["year_began"] == 1998
 
     def test_a_year_outside_every_run_still_matches(self, two_rebirths):
         """The point of leaving `tokenized` unfiltered: a reprint year still lands.

--- a/tests/unit/test_gcd_search_variations.py
+++ b/tests/unit/test_gcd_search_variations.py
@@ -10,6 +10,7 @@ from models.gcd import (
     generate_search_variations,
     lookahead_regex,
     normalize_title,
+    rank_key,
     tokens_for_all_match,
 )
 
@@ -137,3 +138,92 @@ class TestYearConstrainedVariations:
         for title in ["Batman Detective 001", "Batman - Detective (2016)"]:
             emitted.update(t for t, _ in generate_search_variations(title, "2016"))
         assert YEAR_CONSTRAINED_VARIATIONS <= emitted
+
+
+def series(id, name, year_began=None):
+    """A candidate row as the dict row factory returns it."""
+    return {"id": id, "name": name, "year_began": year_began}
+
+
+def best(query, year, candidates):
+    return min(candidates, key=lambda c: rank_key(query, year, c))
+
+
+class TestRankKey:
+    """The selection rule: best candidate, not newest survivor."""
+
+    def test_exact_name_beats_a_longer_name_containing_it(self):
+        """The defect in #519: `exact` is an unanchored LIKE, so a longer
+        series name qualifies and, being newer, used to win."""
+        right = series(1, "Superman", 2000)
+        wrong = series(2, "Mann and Superman", 2000)
+        assert best("Superman", 2000, [wrong, right]) is right
+
+    def test_newer_containing_name_does_not_win(self):
+        """`Saga 012 (2013)` used to match a longer 2013 series."""
+        right = series(1, "Saga", 2012)
+        wrong = series(2, "Michael Turner's Fathom: The Elite Saga", 2013)
+        assert best("Saga", 2013, [wrong, right]) is right
+
+    def test_deluxe_edition_does_not_swallow_the_base_series(self):
+        right = series(1, "Action Comics", 1938)
+        wrong = series(2, "Superman: Action Comics: The Oz Effect - Deluxe Edition", 2018)
+        assert best("Action Comics", 2018, [wrong, right]) is right
+
+    def test_fewer_extra_words_wins_when_neither_is_exact(self):
+        closer = series(1, "The Green Hornet", 1989)
+        further = series(2, "The Green Hornet: Year One Special", 1989)
+        assert best("Green Hornet", 1989, [further, closer]) is closer
+
+    def test_year_only_breaks_ties_between_equally_good_names(self):
+        """Two records with the same name: the parsed year decides."""
+        right = series(1, "Nathan Never", 1991)
+        wrong = series(2, "Nathan Never", 2020)
+        assert best("Nathan Never", 1993, [wrong, right]) is right
+
+    def test_year_does_not_override_name_agreement(self):
+        """A perfect-year wrong name still loses to an exact name."""
+        right = series(1, "Diabolik", 1962)
+        wrong = series(2, "Il grande Diabolik", 2014)
+        assert best("Diabolik", 2014, [wrong, right]) is right
+
+    def test_missing_year_is_not_treated_as_year_zero(self):
+        """An undated series must not outrank a real candidate."""
+        right = series(1, "Topolino", 1949)
+        undated = series(2, "Topolino", None)
+        assert best("Topolino", 1950, [undated, right]) is right
+
+    def test_no_parsed_year_still_ranks_by_name(self):
+        right = series(1, "Dylan Dog", 1986)
+        wrong = series(2, "Dylan Dog Color Fest", 2007)
+        assert best("Dylan Dog", None, [wrong, right]) is right
+
+    def test_string_year_is_accepted(self):
+        """The interactive loop carries the year as the string it parsed."""
+        right = series(1, "Zagor", 1961)
+        wrong = series(2, "Zagor", 2015)
+        assert best("Zagor", "1965", [wrong, right]) is right
+
+    def test_unparseable_year_ties_instead_of_raising(self):
+        a, b = series(1, "Tex", 1948), series(2, "Tex", 1990)
+        assert best("Tex", "n/a", [b, a]) is a
+
+    def test_ranking_ignores_punctuation_and_case(self):
+        right = series(1, "Batman: Detective Comics - Rebirth", 2016)
+        wrong = series(2, "Batman: Detective Comics - Rebirth Deluxe", 2016)
+        assert best("batman detective comics rebirth", 2016, [wrong, right]) is right
+
+    def test_order_is_total_so_input_order_cannot_change_the_winner(self):
+        import itertools
+        cands = [series(1, "Superman", 2000),
+                 series(2, "Mann and Superman", 2000),
+                 series(3, "Superman Family", 2000)]
+        winners = {best("Superman", 2000, list(p))["id"]
+                   for p in itertools.permutations(cands)}
+        assert winners == {1}
+
+    def test_id_is_the_final_tiebreak(self):
+        """Two identical records differ only by id; the lower one wins."""
+        a, b = series(7, "Alan Ford", 1969), series(9, "Alan Ford", 1969)
+        assert best("Alan Ford", 1969, [b, a]) is a
+

--- a/tests/unit/test_gcd_search_variations.py
+++ b/tests/unit/test_gcd_search_variations.py
@@ -7,6 +7,7 @@ import re
 import pytest
 
 from models.gcd import (
+    CANDIDATE_LIMIT,
     generate_search_variations,
     lookahead_regex,
     normalize_title,
@@ -227,3 +228,15 @@ class TestRankKey:
         a, b = series(7, "Alan Ford", 1969), series(9, "Alan Ford", 1969)
         assert best("Alan Ford", 1969, [b, a]) is a
 
+
+class TestCandidateLimit:
+    def test_window_is_wide_enough_to_reach_the_right_series(self):
+        """At 10 the ranker still lost 23 of 10,000 verbatim names, because the
+        right row sat outside the newest ten and never reached it."""
+        assert CANDIDATE_LIMIT >= 200
+
+    def test_is_not_the_main_word_guard(self):
+        """Different policies: one is the ranker's window, the other caps how
+        broad a one-token fallback may be before it declines."""
+        from models.gcd import MAIN_WORD_MAX_CANDIDATES
+        assert CANDIDATE_LIMIT != MAIN_WORD_MAX_CANDIDATES


### PR DESCRIPTION
## 📝 Description
Closes #519

`search_series` and the interactive loop in `routes/metadata.py` both took the first row of `ORDER BY s.year_began DESC`, so the winner was the newest series that survived the filter rather than the best match. `exact` makes it visible: it is an unanchored `LIKE %name%`, so a longer series name containing the parsed title qualifies and, being newer, wins.

```
Superman (2000)  ->  Mann and Superman
```

Both ran in 2000, so the year filter cannot separate them and the tiebreak falls to recency. Same structural weakness as #517, different code path.

Two commits, independent:

1. **Rank the candidates.** `rank_key()` scores each row — normalised name equality first, then words each side has that the other lacks, then length agreement, then distance from the parsed year, with `id` last so the order is total. The year drops from deciding matches to settling ties. It lives in `models/gcd.py` and is called from both loops, following the pattern #527 established with `main_word_token_too_broad`.
2. **Widen the candidate window.** `ORDER BY ... LIMIT 10` decides which rows the ranker can score, so a narrow window hides the right series behind newer ones containing its name. `CANDIDATE_LIMIT = 200` names it. Ranking cannot recover what the query never returned.

## 🛠️ Changes Made
- [x] Added new feature logic — `models/gcd.py` +89, `routes/metadata.py` +10
- [ ] Updated Docker/Config if necessary — no config surface; `CANDIDATE_LIMIT` is a module constant, and no new user-facing setting was added, so nothing in `/docs` applies
- [ ] Verified build locally (`docker build -t dev .`) — not run; tests were run in a container built from `main` with `requirements-test.txt`

## 🧪 Testing Performed
- [ ] Manual test in `dev` container — not performed
- [x] Linting/Unit tests pass — see below

**Suite:** 4,430 passed, 10 failed. The ten are `tests/routes/test_folder_access.py` and `test_library_access.py`, which fail as the identical set on an untouched checkout of `main` in the same container. They look environmental to my setup rather than related to this change, but I cannot rule out that they pass in CI for a reason I am missing — worth a glance.

**Correctness**, measured by inversion: series names taken from the dump and fed back as the parsed title with a year inside each series' own run, so the right answer is guaranteed to exist, be in the right language, and be running in the queried year. 3,000 names per language, against the 2026-08-22 dump. Wrong picks, lower is better:

| Sample | today | rank @10 | **rank @200** |
| --- | ---: | ---: | ---: |
| Italian, verbatim | 101 | 35 | **34** |
| Italian, punctuation rewritten | 117 | 44 | **42** |
| English, verbatim | 319 | 212 | **203** |
| English, punctuation rewritten | 348 | 229 | **219** |

Both languages, because #518 was measured on an Italian-heavy library and the #519 analysis on English names — neither had evidence across both halves.

**What is left wrong**, categorised, because the counts above overstate it:

| | Italian | English |
| --- | ---: | ---: |
| Correct | 2,940 | 2,771 |
| Names normalise identically to the target | 42 | 213 |
| Still a containment failure | 0 | 6 |
| No match at all | 18 | 10 |

The large category is not a selection failure — the dump holds distinct records whose names normalise identically (`L'Uomo Ragno` 1997 and 1999; two `Fantastic Four` (2003)), and nothing can separate them given a name and a year. That leaves **six genuine failures in 3,000 English names and none in 3,000 Italian**, all six pathological short titles where the normalised query is a substring of an unrelated name (`B.C.` normalises to `b c`, which occurs inside `bob colt`).

**Cost of the wider window**, since that is the obvious objection: 3,633 real archives, ladder short-circuiting on first hit as `search_series` does, both limits interleaved and run in both orders so page-cache warming cannot favour either.

| Limit | Total | Per file | Rows fetched |
| ---: | ---: | ---: | ---: |
| 10 | 527.67 s | 145.24 ms | 10,660 |
| 200 | 532.33 s | 146.53 ms | 28,440 |

1.009x — +1.28 ms on a 145 ms baseline for nearly triple the candidates. These queries cost what the unanchored `LIKE` costs to scan `gcd_series`; `LIMIT` only truncates output already found.

## ⚠️ One thing to look at before merging

**This changes a behaviour you introduced deliberately in #527.** At the `tokenized` tier you ordered by distance from the parsed year. Ranking subordinates the year to name agreement, so a candidate whose name normalises exactly to the query now beats a closer-dated one carrying an extra word.

I measured it rather than assuming. Keeping year proximity as the tie-break there is worse on both rewritten samples — 49 wrong against 42 in Italian, 243 against 219 in English — and identical on the verbatim ones. So the change looks right, but it is your call and I would rather flag it than have it slip through.

The two tests pinning the old behaviour are updated, with those numbers in the docstring. I also added a test for the part of #527 that still holds: where two candidates agree with the query equally well, the parsed year still picks the era.

## 🔎 Open question

Ranking applies to every variation, because `results[0]` is wrong in all of them — which makes the change broader than the issue title suggests. Happy to narrow it to the substring variations if you would rather keep the blast radius small.

---

Measurement scripts are not included in the PR. Glad to share them if useful.
