### PR TITLE
Match wanted issues when the rename pattern separates series and issue with "#"

### DIFF
--- a/cbz_ops/rename.py
+++ b/cbz_ops/rename.py
@@ -1004,6 +1004,17 @@ def extract_comic_values(filename, width=3):
         "issue_title": "",
     }
 
+    # Mini-series count: "Adventure Time - Quadruple Feature 01 (of 04) (2026)".
+    # It carries no information any token here wants, and it sits in the one
+    # place that breaks every "Series ## (YYYY)" pattern below -- between the
+    # issue number and the year -- so the whole filename fell through to the
+    # loose fallback, which located the series by searching for the *padded*
+    # issue number ("001", a string the file never contains) and gave back an
+    # empty series. The custom-pattern rename then bailed to the default
+    # renamer and produced a name the wanted-issue matcher was not looking for.
+    # Dropped up front so the ordinary patterns see the ordinary shape.
+    filename = re.sub(r"\s*\(\s*of\s+\d{1,4}\s*\)", "", filename, flags=re.IGNORECASE)
+
     # DC "One Million" exception: these one-shots are literally numbered
     # 1,000,000. Every capture below is bounded to \d{1,4} and would truncate
     # "1000000" to "1000", so pull this exact issue number out first and keep it

--- a/core/database.py
+++ b/core/database.py
@@ -983,6 +983,34 @@ def init_db():
             except sqlite3.OperationalError:
                 pass
 
+        # Same shape, second cause: generate_filename_pattern only relaxed the
+        # series/issue separator when the configured pattern spelled it as a
+        # single space, so every install whose pattern reads
+        # "{series_name} #{issue_number} ..." compiled the "#" as a literal and
+        # the rename-pattern tier never matched. Files without ComicInfo.xml
+        # were cached as missing and re-downloaded forever. The rows outlive
+        # the code fix, so drop them once more.
+        c.execute(
+            "SELECT value FROM user_preferences "
+            "WHERE key = 'collection_status_separator_purge'"
+        )
+        if not c.fetchone():
+            try:
+                c.execute("DELETE FROM collection_status")
+                purged = c.rowcount
+                c.execute("DELETE FROM wanted_issues")
+                c.execute(
+                    "INSERT OR REPLACE INTO user_preferences (key, value, category, updated_at) "
+                    "VALUES ('collection_status_separator_purge', 'true', 'migration', CURRENT_TIMESTAMP)"
+                )
+                if purged:
+                    app_logger.info(
+                        f"Purged {purged} cached collection-status rows "
+                        "(series/issue separator fix); series will re-match on next view"
+                    )
+            except sqlite3.OperationalError:
+                pass
+
         # Create issue_manual_status table (for manually marking issues as owned/skipped)
         c.execute("""
             CREATE TABLE IF NOT EXISTS issue_manual_status (

--- a/helpers/collection.py
+++ b/helpers/collection.py
@@ -327,6 +327,23 @@ def generate_filename_pattern(custom_pattern, series_name, issue_number, strict_
         # Now escape any remaining literal parentheses
         pattern = pattern.replace('(', r'\(').replace(')', r'\)')
 
+        # Mark the literal separator the pattern puts between the series name
+        # and the issue number so it can be relaxed into the flexible gap below.
+        # Only the run of non-alphanumeric literals is marked, and only when the
+        # series comes first, so "{issue_number} - {series_name}" keeps its
+        # anchor. Without this, a pattern that separates the two with anything
+        # other than a single space -- "{series_name} #{issue_number}" is the
+        # common one -- demanded that separator literally, and no file named
+        # "Series 001 (2026).cbz" could ever satisfy it. That is not a
+        # hypothetical shape: the renamer's own fallback logic emits it whenever
+        # the custom pattern can't be filled, so CLU could rename a file into a
+        # name its own matcher then refused.
+        if 0 <= pattern.find('<<<SERIES>>>') < pattern.find('<<<ISSUE>>>'):
+            pattern = re.sub(
+                r'[^A-Za-z0-9<>]*<<<ISSUE>>>', '<<<GAP>>><<<ISSUE>>>',
+                pattern, count=1,
+            )
+
         # Handle "The " prefix - make it optional for matching
         # DB might have "The Ultimates" but files might be "Ultimates"
         working_name = series_name
@@ -383,7 +400,7 @@ def generate_filename_pattern(custom_pattern, series_name, issue_number, strict_
         # above it can no longer swallow leading digits, and ".+?" would otherwise
         # regress "Nightwing001.cbz" (no separator at all) to a non-match.
         gap = _STRICT_GAP if strict_gap else r".*?"
-        pattern = pattern.replace(') (', ")" + gap + "(")
+        pattern = pattern.replace('<<<GAP>>>', gap)
 
         # Defensive: drop any unrecognized {token} (and an empty "()" it may
         # leave behind) so a stray placeholder never becomes a literal regex

--- a/tests/integration/test_database_schema.py
+++ b/tests/integration/test_database_schema.py
@@ -394,6 +394,84 @@ class TestCollectionStatusBoundaryPurge:
         assert self._counts(db_connection) == (1, 1)
 
 
+class TestCollectionStatusSeparatorPurge:
+    """Second one-time purge, for the series/issue separator fix.
+
+    generate_filename_pattern only relaxed the separator between the series
+    name and the issue number when the configured pattern spelled it as a
+    single space, so a pattern like "{series_name} #{issue_number}" required a
+    literal "#" and matched nothing. Files cached as missing under that pattern
+    survive the code fix, so init_db drops the derived caches once.
+    """
+
+    MARKER = "collection_status_separator_purge"
+
+    def _seed(self, conn):
+        from tests.factories.db_factories import create_series, create_issue
+
+        series_id = create_series(name="Nightwing", mapped_path="/data/Nightwing")
+        issue_id = create_issue(series_id=series_id, number="1")
+        conn.execute(
+            "INSERT INTO collection_status "
+            "(series_id, issue_id, issue_number, found, file_path, matched_via) "
+            "VALUES (?, ?, '1', 0, NULL, NULL)",
+            (series_id, issue_id),
+        )
+        conn.execute(
+            "INSERT INTO wanted_issues (series_id, issue_id, issue_number) "
+            "VALUES (?, ?, '1')",
+            (series_id, issue_id),
+        )
+        conn.execute(
+            "DELETE FROM user_preferences WHERE key = ?", (self.MARKER,)
+        )
+        conn.commit()
+        return series_id, issue_id
+
+    def _counts(self, conn):
+        cs = conn.execute("SELECT COUNT(*) FROM collection_status").fetchone()[0]
+        wi = conn.execute("SELECT COUNT(*) FROM wanted_issues").fetchone()[0]
+        return cs, wi
+
+    def test_purges_stale_rows_and_sets_marker(self, db_connection, db_path):
+        self._seed(db_connection)
+
+        with patch("core.database.get_db_path", return_value=db_path):
+            from core.database import init_db
+            assert init_db() is True
+
+        assert self._counts(db_connection) == (0, 0)
+        assert db_connection.execute(
+            "SELECT value FROM user_preferences WHERE key=?", (self.MARKER,)
+        ).fetchone() is not None
+
+    def test_does_not_repurge_once_marked(self, db_connection, db_path):
+        series_id, issue_id = self._seed(db_connection)
+
+        with patch("core.database.get_db_path", return_value=db_path):
+            from core.database import init_db
+            init_db()
+
+            # Freshly matched rows written after the purge must survive a later
+            # startup.
+            db_connection.execute(
+                "INSERT INTO collection_status "
+                "(series_id, issue_id, issue_number, found, file_path, matched_via) "
+                "VALUES (?, ?, '1', 1, '/data/Nightwing/Nightwing 001 (2016).cbz', 'pattern')",
+                (series_id, issue_id),
+            )
+            db_connection.execute(
+                "INSERT INTO wanted_issues (series_id, issue_id, issue_number) "
+                "VALUES (?, ?, '2')",
+                (series_id, issue_id),
+            )
+            db_connection.commit()
+
+            init_db()
+
+        assert self._counts(db_connection) == (1, 1)
+
+
 class TestDownloadClientGroupMigration:
     """download_clients.client_group was added after the table shipped."""
 

--- a/tests/unit/test_filename_pattern.py
+++ b/tests/unit/test_filename_pattern.py
@@ -679,3 +679,65 @@ class TestStrictGap:
             self.PATTERN, self.SERIES, "3", strict_gap=True
         )
         assert not regex.match(self.SERIES + " " + "- x " * 60 + ".cbz")
+
+
+class TestLiteralSeparatorBetweenSeriesAndIssue:
+    """The pattern's own separator must not become a hard requirement.
+
+    "{series_name} #{issue_number}" is a common configured pattern, and only
+    the exact ") (" boundary used to be relaxed into the flexible gap, so the
+    "#" was compiled as a literal. Every file named without one -- including
+    the ones CLU's own renamer produces when the custom pattern can't be
+    filled -- then failed to match, and a downloaded issue sat in TARGET
+    forever while the series page kept reporting it missing.
+    """
+
+    SERIES = "Adventure Time: Quadruple Feature"
+    FILE = "Adventure Time - Quadruple Feature 001 (2026).cbz"
+
+    @pytest.mark.parametrize("pattern", [
+        "{series_name} #{issue_number}",
+        "{series_name} {issue_number}",
+        "{series_name} - {issue_number}",
+        "{series_name}_{issue_number}",
+        "{series_name}{issue_number}",
+    ])
+    @pytest.mark.parametrize("strict", [False, True])
+    def test_separator_is_not_required_literally(self, pattern, strict):
+        regex = generate_filename_pattern(
+            pattern, self.SERIES, "1", strict_gap=strict
+        )
+        assert regex.match(self.FILE)
+
+    def test_hash_in_the_file_still_matches(self):
+        regex = generate_filename_pattern(
+            "{series_name} #{issue_number}", self.SERIES, "1", strict_gap=True
+        )
+        assert regex.match("Adventure Time - Quadruple Feature #001 (2026).cbz")
+
+    def test_relaxing_the_separator_keeps_the_spinoff_guard(self):
+        # The gap is still _STRICT_GAP, so a subtitle between the series and
+        # the issue is rejected however the pattern spells its separator.
+        regex = generate_filename_pattern(
+            "{series_name} #{issue_number}",
+            "Teenage Mutant Ninja Turtles",
+            "3",
+            strict_gap=True,
+        )
+        assert not regex.match(
+            "Teenage Mutant Ninja Turtles - Nightwatcher 003.cbz"
+        )
+
+    def test_relaxing_the_separator_adds_no_capture_group(self):
+        regex = generate_filename_pattern(
+            "{series_name} #{issue_number}", self.SERIES, "1", strict_gap=True
+        )
+        assert regex.match(self.FILE).group(1) == "001"
+
+    def test_issue_before_series_keeps_its_anchor(self):
+        # "{issue_number} - {series_name}" must not have its leading literal
+        # turned into a wildcard, which would unanchor the whole match.
+        regex = generate_filename_pattern(
+            "#{issue_number} - {series_name}", "Batman", "1"
+        )
+        assert not regex.match("Detective Comics 900 - #001 - Batman.cbz")

--- a/tests/unit/test_match_wanted_to_files.py
+++ b/tests/unit/test_match_wanted_to_files.py
@@ -491,3 +491,47 @@ class TestNegativeIssueNumbers:
             wanted, [("unhelpful.cbz", f)], PATTERN, alias_lookup=_no_aliases
         )
         assert matches == []
+
+
+class TestHashSeparatorPattern:
+    """A configured "#" separator must not strand the download in TARGET.
+
+    Reported against 'Adventure Time - Quadruple Feature 001 (2026).cbz': the
+    file downloaded, converted and landed in TARGET, but the sweep kept
+    reporting #1 missing because the configured pattern
+    "{series_name} #{issue_number} ..." compiled the "#" as a literal.
+    """
+
+    HASH_PATTERN = "{series_name} #{issue_number}"
+
+    def test_file_without_hash_matches_hash_pattern(self, tmp_path):
+        series_dir = tmp_path / "Adventure Time - Quadruple Feature (2026)"
+        series_dir.mkdir()
+        name = "Adventure Time - Quadruple Feature 001 (2026).cbz"
+        f = str(tmp_path / name)
+        _touch(f)
+
+        matches = match_wanted_issues_to_files(
+            [_wanted("Adventure Time: Quadruple Feature", "1", str(series_dir))],
+            [(name, f)],
+            self.HASH_PATTERN,
+            alias_lookup=_no_aliases,
+        )
+
+        assert [m["filename"] for m in matches] == [name]
+
+    def test_spinoff_still_rejected_under_a_hash_pattern(self, tmp_path):
+        series_dir = tmp_path / "TMNT"
+        series_dir.mkdir()
+        name = "Teenage Mutant Ninja Turtles - Nightwatcher 003.cbz"
+        f = str(tmp_path / name)
+        _touch(f)
+
+        matches = match_wanted_issues_to_files(
+            [_wanted("Teenage Mutant Ninja Turtles", "3", str(series_dir))],
+            [(name, f)],
+            self.HASH_PATTERN,
+            alias_lookup=_no_aliases,
+        )
+
+        assert matches == []

--- a/tests/unit/test_rename.py
+++ b/tests/unit/test_rename.py
@@ -757,6 +757,46 @@ class TestExtractComicValues:
         assert values["issue_number"] == expected_issue
         assert values["year"] == expected_year
 
+    @pytest.mark.parametrize("filename,expected_series,expected_issue,expected_year", [
+        # "(of NN)" mini-series count between the issue number and the year.
+        # It broke every "Series ## (YYYY)" pattern, so the name fell through
+        # to the loose fallback, which returned an empty series -- the
+        # custom-pattern rename then bailed to the default renamer and emitted
+        # a name the wanted-issue matcher was not looking for, stranding the
+        # download in TARGET.
+        (
+            "Adventure Time - Quadruple Feature 01 (of 04) (2026) (Digital Rip) (Hourman-DCP).cbr",
+            "Adventure Time - Quadruple Feature",
+            "001",
+            "2026",
+        ),
+        (
+            "Absolute Batman 03 (of 12) (2025) (Digital) (Zone-Empire).cbz",
+            "Absolute Batman",
+            "003",
+            "2025",
+        ),
+        # Spacing/case variants of the same marker
+        ("Saga 007 (Of 12) (2013).cbz", "Saga", "007", "2013"),
+        ("Saga 007 ( of 12 ) (2013).cbz", "Saga", "007", "2013"),
+    ])
+    def test_mini_series_count_marker_is_ignored(
+        self, filename, expected_series, expected_issue, expected_year
+    ):
+        from cbz_ops.rename import extract_comic_values
+        values = extract_comic_values(filename)
+        assert values["series_name"] == expected_series
+        assert values["issue_number"] == expected_issue
+        assert values["year"] == expected_year
+
+    def test_of_is_not_stripped_from_a_real_title(self):
+        # Only the parenthesised "(of NN)" count is dropped -- "of" inside a
+        # series name must survive.
+        from cbz_ops.rename import extract_comic_values
+        values = extract_comic_values("House of Secrets 012 (1970).cbz")
+        assert values["series_name"] == "House of Secrets"
+        assert values["issue_number"] == "012"
+
     def test_returns_all_keys(self):
         from cbz_ops.rename import extract_comic_values
         values = extract_comic_values("Batman 001 (2020).cbz")


### PR DESCRIPTION
## The report

`Adventure Time - Quadruple Feature 001 (2026).cbz` downloaded, converted, and landed in TARGET — then sat there while the nightly sweep kept reporting `'Adventure Time: Quadruple Feature' #1` missing:

```
=== Checking 77 MISSING issues against TARGET folder ===
  MISSING: 'Adventure Time: Quadruple Feature' #1 (mapped: /data/Oni Press/Adventure Time - Quadruple Feature (2026))
Found 1 comic files in TARGET folder (including subdirectories):
  FILE: /downloads/processed/Adventure Time - Quadruple Feature 001 (2026).cbz
```

Two independent defects had to line up.

## 1. The matcher required the pattern's own `#` literally

`helpers/collection.py` — `generate_filename_pattern`

The configured pattern is `{series_name} #{issue_number} ({issue_year}-{issue_month_m})`, which the caller strips down to `{series_name} #{issue_number}`. The separator between series and issue was only relaxed into the flexible gap by a literal `pattern.replace(') (', ...)`, which matches exactly one space. With a `#` the boundary reads `) #(`, so nothing was substituted and the `#` compiled as a hard requirement:

```
(?:Adventure[…]*Time[…]*Quadruple[…]*Feature) #((?<!\d)…0*1(?!\d)(?!\.\d)).*\.(?:cbz|cbr|zip|rar)$
```

No file named `Series 001 (2026).cbz` could ever satisfy that — for any series, for as long as that pattern is configured.

The literal separator run is now marked before substitution and replaced by the same gap, and only when the series comes first, so `{issue_number} - {series_name}` keeps its anchor. The gap is still `_STRICT_GAP` under `strict_gap=True`, so nothing about the existing guards changes — verified across both pattern shapes:

| file | wanted | before | after |
|---|---|---|---|
| `TMNT - Nightwatcher 003 (2024).cbz` | TMNT #3 | reject | reject |
| `Nightwing 117 - Absolute Power.cbz` | #117 | match | match |
| `Nightwing 051 (2016).cbz` | #1 | reject | reject |
| `Amazing Spider-Man -001 (1997).cbz` | #1 / #-1 | reject / match | reject / match |
| `Nightwing001.cbz` | #1 | match | match |

## 2. `(of 04)` broke the rename that would have produced a conforming name

`cbz_ops/rename.py` — `extract_comic_values`

This is the `Missing series_name` warning in the log — and the name that failed to match was one CLU itself produced:

```
Attempting to rename: Adventure Time - Quadruple Feature 01 (of 04) (2026) (Digital Rip) (Hourman-DCP).cbr
Extracted comic values: {'series_name': '', …, 'issue_number': '001', 'issue_year': '2026'}
WARNING - Missing series_name in extracted values
Custom rename pattern failed, falling back to default logic
```

The `(of 04)` mini-series count sits between the issue number and the year, which defeats every `Series ## (YYYY)` pattern, so the name fell through to the loose fallback. That fallback locates the series by searching the filename for the **padded** issue number — `"001"`, a string the file spells `"01"` — found nothing, and returned an empty series. The custom pattern bailed, the default renamer emitted a name with no `#`, and defect 1 then refused it.

The marker is dropped up front so the ordinary patterns see the ordinary shape. The file now renames to `Adventure Time - Quadruple Feature #001 (2026).cbz`.

I first fixed this by tracking the real match position instead. That made a messy scene name (`Batman 046 52p ctc 04-05 (1948).cbz`) extract a junk series *confidently* rather than failing safely into the default renamer — `test_half_matching_messy_name_still_renames` caught it, and I went with the targeted marker strip.

## 3. One-time cache purge

`core/database.py`

Per the matcher-change rule, the code fix alone corrects nothing for existing installs: `collection_status` is write-once and `match_unmatched_mapped_series` skips any series that already has cached status, so issues cached as missing under the broken pattern stay missing and `wanted_issues` stays wrong — auto-download keeps re-fetching them. Adds a `collection_status_separator_purge` marker mirroring the existing `collection_status_boundary_purge`; both derived caches drop once at startup and re-match. Manual owned/skipped state in `issue_manual_status` is untouched.

## Tests

New regression classes in `test_filename_pattern.py` (separator shapes × strict/loose, guards preserved, no new capture group, issue-before-series anchor), `test_match_wanted_to_files.py` (the reported file end to end, plus the spin-off still rejected under a `#` pattern), `test_rename.py` (`(of NN)` variants, and `"of"` inside a real title left alone), and `test_database_schema.py` (purge + no re-purge).

Full suite: **4507 passed, 7 skipped** (the usual POSIX-only skips).

## After merge

The stranded file will be claimed by the next sweep and moved into its series folder. Once startup repopulates the caches, "Re-match Files" on the Pull List is worth a click if other series look wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BYB2bF4mdCDQXB4wya4PfS
