### PR TITLE
Explain Cloudflare-blocked downloads on the status page

### DIFF
--- a/templates/status.html
+++ b/templates/status.html
@@ -147,6 +147,30 @@
       }
     }
 
+    // A Cloudflare-blocked download carries the original GetComics link in
+    // `manual_url` (set by api.py's challenge branch and preserved across
+    // mirror failover). Only http(s) links are offered: the value ends up in an
+    // anchor, and a javascript:/data: URL there would be a script-injection
+    // vector if the field were ever fed from somewhere less trustworthy.
+    function manualDownloadUrl(details) {
+      const url = details && details.manual_url;
+      if (typeof url !== 'string') return null;
+      return /^https?:\/\//i.test(url.trim()) ? url.trim() : null;
+    }
+
+    // Link button that opens the source page so the user can clear the
+    // challenge in a real browser and download the file by hand.
+    function manualDownloadLink(url) {
+      const a = document.createElement('a');
+      a.href = url;            // set as a property, never interpolated into HTML
+      a.target = '_blank';
+      a.rel = 'noopener';
+      a.className = 'btn btn-sm btn-warning me-2';
+      a.title = 'Cloudflare blocked the automatic download — open the source page and download it manually';
+      a.innerHTML = '<i class="bi bi-box-arrow-up-right me-1"></i>Download manually';
+      return a;
+    }
+
     // Render direct (api.py) download rows into the table body.
     function renderDirectRows(tbody, data) {
       for (const [downloadId, details] of Object.entries(data)) {
@@ -159,8 +183,20 @@
             // Status
             let statusClass = '';
             let statusText = details.status;
+            let statusTitle = details.error;
             if (details.status === 'error') {
               statusClass = 'text-danger fw-bold';
+              if (manualDownloadUrl(details)) {
+                // Cloudflare: the mirror answered with a managed challenge, which
+                // no automated client can pass. Say so plainly instead of leaving
+                // the user staring at a bare "error" they can't act on — the
+                // Actions column carries the link that does work.
+                statusText = 'Blocked by Cloudflare';
+                statusClass = 'text-warning fw-bold';
+                statusTitle = 'This mirror is protected by a Cloudflare challenge '
+                            + 'that cannot be bypassed automatically. Use the link '
+                            + 'in Actions to download it in your browser.';
+              }
             } else if (details.status === 'complete') {
               statusClass = 'text-success';
             } else if (details.status === 'cancelled') {
@@ -173,7 +209,7 @@
               statusText = `Retrying in ${formatCountdown(details.retry_in)}`
                          + ` (${details.retry_count} of ${details.retry_max})`;
             }
-            tr.appendChild(statusCell(statusText, statusClass, details.error));
+            tr.appendChild(statusCell(statusText, statusClass, statusTitle));
 
             // Actions cell (Cancel/Retry buttons)
             const tdActions = document.createElement('td');
@@ -207,6 +243,13 @@
               });
               tdActions.appendChild(cancelIcon);
             } else if (details.status === 'error') {
+              // Cloudflare failures come first: retrying is pointless there, so
+              // lead with the link that actually gets the file.
+              const manualUrl = manualDownloadUrl(details);
+              if (manualUrl) {
+                tdActions.appendChild(manualDownloadLink(manualUrl));
+              }
+
               // Retry button for error status
               const retryIcon = document.createElement('i');
               retryIcon.className = "bi bi-arrow-clockwise text-primary action-icon";

--- a/tests/unit/test_status_page_cloudflare.py
+++ b/tests/unit/test_status_page_cloudflare.py
@@ -1,0 +1,53 @@
+"""The /status page has to say *why* a Cloudflare-blocked download failed.
+
+A managed Cloudflare challenge is the one failure CLU cannot retry its way out
+of (`should_auto_retry` refuses as soon as `manual_url` is set), so the row is
+terminal and the user has to fetch the file in a browser themselves. If the
+page only ever showed "error" there would be nothing on screen telling them
+that, nor anything to click.
+
+These are text assertions rather than route tests because the rendering lives
+in status.html's own JavaScript — there is no Python to exercise. They guard
+the two things that must not quietly disappear: the manual_url branch, and the
+http(s)-only guard on the URL that ends up in an anchor's href.
+"""
+
+from pathlib import Path
+
+import pytest
+
+STATUS_HTML = Path(__file__).resolve().parents[2] / "templates" / "status.html"
+
+
+@pytest.fixture(scope="module")
+def status_source():
+    return STATUS_HTML.read_text(encoding="utf-8")
+
+
+class TestCloudflareRow:
+    def test_reads_manual_url_from_the_progress_entry(self, status_source):
+        """api.py records the link on the progress dict and
+        build_status_snapshot passes it straight through, so the field name is
+        a contract between the two."""
+        assert "details.manual_url" in status_source
+
+    def test_status_cell_names_cloudflare(self, status_source):
+        assert "Blocked by Cloudflare" in status_source
+
+    def test_offers_a_manual_download_link(self, status_source):
+        assert "manualDownloadLink" in status_source
+        assert "Download manually" in status_source
+
+    def test_link_opens_in_a_new_tab_without_opener(self, status_source):
+        assert "a.target = '_blank'" in status_source
+        assert "a.rel = 'noopener'" in status_source
+
+    def test_only_http_urls_are_turned_into_links(self, status_source):
+        """The value lands in an href, so a javascript:/data: URL would be an
+        injection vector if manual_url ever came from somewhere less trusted."""
+        assert r"/^https?:\/\//i" in status_source
+
+    def test_href_is_assigned_not_interpolated(self, status_source):
+        """Building the anchor with innerHTML would put the URL inside markup;
+        assigning the property keeps it data."""
+        assert "a.href = url;" in status_source


### PR DESCRIPTION
## Problem

A managed Cloudflare challenge is the one download failure CLU cannot retry its way out of — `should_auto_retry` refuses as soon as `manual_url` is set, so the row is terminal and the file only arrives if the user fetches it in a real browser.

Until now `/status` showed a bare **error** for those, with nothing on screen saying why, and a Retry button that could only fail again. The manual link existed (`api.py` records it, `build_status_snapshot` passes it through, `series.html` shows it in a toast) but never reached the Download Status page.

## Change

Template-only — no server change, `api.py` untouched.

- **Status column** reads **"Blocked by Cloudflare"** in warning styling, with a hover title explaining that no automated client can pass a managed challenge and pointing at the link in Actions.
- **Actions column** leads with a **"Download manually"** button opening the original GetComics page, ahead of Retry and Dismiss — retry is pointless here, so the action that works comes first.

Only `http(s)` URLs are turned into links, and the href is assigned as a property rather than interpolated into markup: the value ends up in an anchor, so a `javascript:`/`data:` URL would be an injection vector if `manual_url` were ever fed from somewhere less trustworthy.

## Tests

New `tests/unit/test_status_page_cloudflare.py` (6 tests) guards the `manual_url` field name shared with `api.py`, the label, the link, `target="_blank" rel="noopener"`, the http(s)-only guard, and that the href is assigned rather than built via `innerHTML`.

Full suite: **4512 passed, 7 skipped**. One unrelated failure, `tests/routes/test_database.py::TestDatabaseRestore::test_restore_round_trip` — the known Windows full-run flake; it passes in isolation (27/27).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BYB2bF4mdCDQXB4wya4PfS
