### PR TITLE
Let the reader pan the zoom window, by keyboard and by wheel

### DIFF
--- a/static/css/reader.css
+++ b/static/css/reader.css
@@ -381,25 +381,45 @@
     color: #212529 !important;
 }
 
-/* Zoom indicator hint */
-.comic-reader-zoom-hint {
+/* Pan hint -- injected by reader.js the first few times a page is zoomed in,
+   because zoom always centres and the pan keys are not otherwise discoverable.
+   Built in JS rather than markup: the reader modal is duplicated across four
+   templates, and this keeps those copies from drifting. */
+.reader-pan-hint {
     position: absolute;
     bottom: 80px;
     left: 50%;
     transform: translateX(-50%);
-    background: rgba(0, 0, 0, 0.7);
-    color: white;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    max-width: calc(100% - 2rem);
+    background: rgba(0, 0, 0, 0.78);
+    color: #fff;
     padding: 0.5rem 1rem;
     border-radius: 20px;
     font-size: 0.8rem;
+    line-height: 1.4;
     opacity: 0;
     transition: opacity 0.3s ease;
     pointer-events: none;
     z-index: 10;
 }
 
-.comic-reader-zoom-hint.visible {
+.reader-pan-hint.visible {
     opacity: 1;
+}
+
+/* Fixed colours, not theme tokens: this sits on the artwork, which reader.js
+   recolours per page, so it must stay legible against anything. */
+.reader-pan-hint kbd {
+    background: rgba(255, 255, 255, 0.16);
+    color: #fff;
+    border-radius: 4px;
+    padding: 0.05rem 0.3rem;
+    margin: 0 0.1rem;
+    font-size: 0.75rem;
+    box-shadow: none;
 }
 
 /* Next Issue Overlay Styles */

--- a/static/js/reader.js
+++ b/static/js/reader.js
@@ -54,6 +54,41 @@ const COMIC_EXTENSIONS = ['.cbz', '.cbr', '.cb7', '.zip', '.rar', '.7z', '.pdf']
 // Zoom step levels: 3 increments from minRatio (1) to maxRatio (3)
 const ZOOM_STEPS = [1, 1.67, 2.33, 3];
 
+// --- Panning the zoom window -------------------------------------------------
+// Zooming always centres on the page, so without these the zoomed-in reader can
+// only ever show the middle of the artwork. Keys that pan:
+//
+//   Shift/Ctrl + arrows   pan (arrows need a modifier -- bare arrows are
+//                         already page-turn (left/right) and zoom (up/down))
+//   W A S D               pan, no modifier needed
+//   0 / Home              re-centre without changing the zoom level
+//   wheel                 pan vertically; Shift+wheel pans horizontally
+//
+// One key press moves the view by this fraction of the visible page, so the
+// step stays useful at every zoom level (a fixed pixel step is imperceptible
+// at 3x on a large display).
+const PAN_STEP_FRACTION = 0.2;
+
+// Wheel deltas arrive in three units depending on the device and browser;
+// normalise them to pixels before treating them as a pan distance.
+const WHEEL_LINE_HEIGHT = 16;
+
+// Keys that pan, mapped to a direction. Direction is the direction the VIEW
+// moves, so the image translates the opposite way -- the scroll convention.
+const PAN_KEYS = {
+    ArrowUp: 'up', ArrowDown: 'down', ArrowLeft: 'left', ArrowRight: 'right',
+    w: 'up', W: 'up', s: 'down', S: 'down',
+    a: 'left', A: 'left', d: 'right', D: 'right'
+};
+
+// The pan hint is a one-off nudge, not a permanent HUD: it appears the first
+// time the user zooms in and then only for the first few sessions ever.
+const PAN_HINT_STORAGE_KEY = 'cluReaderPanHintSeen';
+const PAN_HINT_MAX_SHOWS = 3;
+const PAN_HINT_DURATION_MS = 4000;
+let panHintTimeout = null;
+let panHintShownThisSession = false;
+
 /**
  * Encode a file path for URL while preserving slashes
  * @param {string} path - The file path to encode
@@ -67,12 +102,29 @@ function encodeFilePath(path) {
 }
 
 /**
+ * Is the key going to a control that owns its own keyboard handling?
+ *
+ * The reader's own page selector is a <select>: swallowing Space there would
+ * stop it opening, and swallowing W/A/S/D would break its typeahead. The reader
+ * binds on `document`, so this is the only thing keeping those keys off it.
+ *
+ * @param {EventTarget} target
+ * @returns {boolean}
+ */
+function _isFormControlTarget(target) {
+    if (!target || !target.tagName) return false;
+    if (target.isContentEditable) return true;
+    return ['INPUT', 'SELECT', 'TEXTAREA'].includes(target.tagName);
+}
+
+/**
  * Handle keydown events specific to comic reader (spacebar only)
  * Arrow keys are handled by handleZoomKeyboard
  * @param {KeyboardEvent} e - The keydown event
  */
 function handleComicReaderKeydown(e) {
     if (!comicReaderSwiper) return;
+    if (_isFormControlTarget(e.target)) return;
 
     // Spacebar to advance
     if (e.code === 'Space') {
@@ -533,6 +585,7 @@ function initializeComicReader(pageCount, startPage = 0) {
                     this.zoom.out();
                 } else {
                     this.zoom.in();
+                    maybeShowPanHint();
                 }
             },
             init: function () {
@@ -607,6 +660,9 @@ function stepZoom(direction) {
         for (let i = 0; i < ZOOM_STEPS.length; i++) {
             if (ZOOM_STEPS[i] > current + 0.01) {
                 comicReaderSwiper.zoom.in(ZOOM_STEPS[i]);
+                // Zoom always lands on the centre of the page; tell the user how
+                // to get to the rest of it.
+                maybeShowPanHint();
                 return;
             }
         }
@@ -658,53 +714,201 @@ function initializeZoomControls() {
 }
 
 /**
- * Pan the zoomed view by modifying the zoom container's transform
- * @param {string} direction - Arrow key direction ('ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight')
+ * Resolve everything needed to pan the current page, or null if there is
+ * nothing to pan (reader closed, page not loaded yet, or not zoomed in).
+ *
+ * Swiper splits the zoom across two elements: `translate3d()` on the
+ * `.swiper-zoom-container`, `scale()` on the `<img>` inside it. We therefore
+ * read and write ONLY the container's translate -- appending a `scale()` of our
+ * own there multiplies against the image's and blows the page up on the first
+ * pan. Swiper re-reads that translate off the DOM on touchstart, so panning by
+ * keyboard and then by drag picks up exactly where the keyboard left off.
+ *
+ * @returns {?{zoomContainer: HTMLElement, slide: HTMLElement, x: number,
+ *            y: number, maxX: number, maxY: number}}
  */
-function panZoomedView(direction) {
-    if (!comicReaderSwiper) return;
+function getZoomPanContext() {
+    if (!comicReaderSwiper || !comicReaderSwiper.zoom) return null;
 
-    const activeSlide = comicReaderSwiper.slides[comicReaderSwiper.activeIndex];
-    if (!activeSlide) return;
-
-    const zoomContainer = activeSlide.querySelector('.swiper-zoom-container');
-    if (!zoomContainer) return;
-
-    const PAN_STEP = 50;
-    const transform = zoomContainer.style.transform || '';
     const scale = comicReaderSwiper.zoom.scale || 1;
+    if (scale <= 1) return null;
 
-    // Parse current translate3d values
-    let currentX = 0, currentY = 0;
-    const match = transform.match(/translate3d\(\s*([-\d.]+)px\s*,\s*([-\d.]+)px\s*,/);
+    const slide = comicReaderSwiper.slides[comicReaderSwiper.activeIndex];
+    if (!slide) return null;
+
+    const zoomContainer = slide.querySelector('.swiper-zoom-container');
+    const img = zoomContainer ? zoomContainer.querySelector('img') : null;
+    if (!zoomContainer || !img) return null;
+
+    // Same bounds Swiper uses for drag panning: half the overhang of the scaled
+    // image past the slide on each axis. offsetWidth/Height are layout sizes and
+    // so are unaffected by the transform.
+    const maxX = Math.max(0, (img.offsetWidth * scale - slide.offsetWidth) / 2);
+    const maxY = Math.max(0, (img.offsetHeight * scale - slide.offsetHeight) / 2);
+
+    let x = 0, y = 0;
+    const match = (zoomContainer.style.transform || '')
+        .match(/translate3d\(\s*(-?[\d.]+)px\s*,\s*(-?[\d.]+)px/);
     if (match) {
-        currentX = parseFloat(match[1]);
-        currentY = parseFloat(match[2]);
+        x = parseFloat(match[1]) || 0;
+        y = parseFloat(match[2]) || 0;
     }
 
-    // Apply delta
+    return { zoomContainer, slide, x, y, maxX, maxY };
+}
+
+/**
+ * Write a clamped pan offset onto the zoom container.
+ * @param {Object} ctx - Context from getZoomPanContext()
+ * @param {number} x - Desired horizontal offset in px
+ * @param {number} y - Desired vertical offset in px
+ */
+function applyZoomPan(ctx, x, y) {
+    const clampedX = Math.max(-ctx.maxX, Math.min(ctx.maxX, x));
+    const clampedY = Math.max(-ctx.maxY, Math.min(ctx.maxY, y));
+
+    // Swiper leaves a 300ms transition on the container after a zoom step, which
+    // makes a held-down pan key lag well behind the keyboard. Swiper restores
+    // the duration itself on its next zoom in/out, so this is safe to clear.
+    ctx.zoomContainer.style.transitionDuration = '0ms';
+    ctx.zoomContainer.style.transform =
+        `translate3d(${clampedX}px, ${clampedY}px, 0px)`;
+
+    // The user has clearly found the controls; stop telling them about them.
+    if (panHintTimeout) hidePanHint();
+}
+
+/**
+ * Pan the zoomed page by a pixel delta.
+ * @param {number} dx - Horizontal delta applied to the image
+ * @param {number} dy - Vertical delta applied to the image
+ * @returns {boolean} True if a pan was applied
+ */
+function panZoomedView(dx, dy) {
+    const ctx = getZoomPanContext();
+    if (!ctx) return false;
+    if (!dx && !dy) return false;
+    applyZoomPan(ctx, ctx.x + dx, ctx.y + dy);
+    return true;
+}
+
+/**
+ * Pan by one key press: a fraction of the visible page in the given direction.
+ * @param {'up'|'down'|'left'|'right'} direction - Direction the VIEW moves
+ * @returns {boolean} True if a pan was applied
+ */
+function panZoomedViewByKey(direction) {
+    const ctx = getZoomPanContext();
+    if (!ctx) return false;
+
+    const stepX = ctx.slide.offsetWidth * PAN_STEP_FRACTION;
+    const stepY = ctx.slide.offsetHeight * PAN_STEP_FRACTION;
+
+    let dx = 0, dy = 0;
     switch (direction) {
-        case 'ArrowUp':    currentY += PAN_STEP; break;
-        case 'ArrowDown':  currentY -= PAN_STEP; break;
-        case 'ArrowLeft':  currentX += PAN_STEP; break;
-        case 'ArrowRight': currentX -= PAN_STEP; break;
+        case 'up':    dy = stepY; break;
+        case 'down':  dy = -stepY; break;
+        case 'left':  dx = stepX; break;
+        case 'right': dx = -stepX; break;
+        default: return false;
     }
 
-    // Clamp to image bounds
-    const img = zoomContainer.querySelector('img');
-    if (img) {
-        const containerRect = zoomContainer.parentElement.getBoundingClientRect();
-        const scaledWidth = img.offsetWidth * scale;
-        const scaledHeight = img.offsetHeight * scale;
+    applyZoomPan(ctx, ctx.x + dx, ctx.y + dy);
+    return true;
+}
 
-        const maxX = Math.max(0, (scaledWidth - containerRect.width) / 2);
-        const maxY = Math.max(0, (scaledHeight - containerRect.height) / 2);
+/**
+ * Re-centre the zoom window without changing the zoom level.
+ * @returns {boolean} True if the view was re-centred
+ */
+function recenterZoomedView() {
+    const ctx = getZoomPanContext();
+    if (!ctx) return false;
+    applyZoomPan(ctx, 0, 0);
+    return true;
+}
 
-        currentX = Math.max(-maxX, Math.min(maxX, currentX));
-        currentY = Math.max(-maxY, Math.min(maxY, currentY));
+/**
+ * Normalise a wheel delta to pixels. Firefox reports lines (deltaMode 1) and,
+ * for page-scroll gestures, pages (deltaMode 2); untranslated, a delta of 3
+ * would read as a 3px pan and the wheel would feel dead when zoomed.
+ * @param {number} delta - Raw delta from the wheel event
+ * @param {number} mode - event.deltaMode
+ * @param {number} pageSize - Size of the viewport along this axis
+ * @returns {number} Delta in pixels
+ */
+function normalizeWheelDelta(delta, mode, pageSize) {
+    if (mode === 1) return delta * WHEEL_LINE_HEIGHT;
+    if (mode === 2) return delta * pageSize;
+    return delta;
+}
+
+/**
+ * Show the "you can pan now" hint, unless the user has seen it enough times.
+ * Called when the reader zooms in. Keyboard-only advice, so it is skipped on
+ * touch layouts where pinch-and-drag is already the obvious gesture.
+ */
+function maybeShowPanHint() {
+    if (panHintShownThisSession || isMobileOrTablet()) return;
+
+    let seen = 0;
+    try {
+        seen = parseInt(localStorage.getItem(PAN_HINT_STORAGE_KEY), 10) || 0;
+    } catch (e) {
+        // Private mode / blocked storage: show the hint, just don't remember it.
+    }
+    if (seen >= PAN_HINT_MAX_SHOWS) return;
+
+    const hint = ensurePanHintElement();
+    if (!hint) return;
+
+    panHintShownThisSession = true;
+    try {
+        localStorage.setItem(PAN_HINT_STORAGE_KEY, String(seen + 1));
+    } catch (e) {
+        // Non-fatal, as above.
     }
 
-    zoomContainer.style.transform = `translate3d(${currentX}px, ${currentY}px, 0px) scale(${scale})`;
+    hint.classList.add('visible');
+    clearTimeout(panHintTimeout);
+    panHintTimeout = setTimeout(hidePanHint, PAN_HINT_DURATION_MS);
+}
+
+/** Hide the pan hint and cancel its timer. */
+function hidePanHint() {
+    clearTimeout(panHintTimeout);
+    panHintTimeout = null;
+    const hint = document.getElementById('readerPanHint');
+    if (hint) hint.classList.remove('visible');
+}
+
+/**
+ * Build the pan hint on first use.
+ *
+ * Created here rather than in markup because the reader modal is duplicated
+ * across four templates (collection, metadata_browser, reading_list_view,
+ * source_wall) -- injecting it keeps those four copies from drifting.
+ *
+ * @returns {?HTMLElement}
+ */
+function ensurePanHintElement() {
+    const existing = document.getElementById('readerPanHint');
+    if (existing) return existing;
+
+    const container = document.querySelector('.comic-reader-container');
+    if (!container) return null;
+
+    const hint = document.createElement('div');
+    hint.id = 'readerPanHint';
+    hint.className = 'reader-pan-hint';
+    hint.setAttribute('role', 'status');
+    hint.innerHTML =
+        '<i class="bi bi-arrows-move" aria-hidden="true"></i>' +
+        '<span>Pan with <kbd>Shift</kbd>+arrows, <kbd>W</kbd><kbd>A</kbd>' +
+        '<kbd>S</kbd><kbd>D</kbd> or the scroll wheel &middot; ' +
+        '<kbd>0</kbd> to re-centre</span>';
+    container.appendChild(hint);
+    return hint;
 }
 
 /**
@@ -726,17 +930,39 @@ function isLightColor(r, g, b) {
 function handleZoomKeyboard(event) {
     // Only handle if comic reader is open
     if (!comicReaderSwiper) return;
+    if (_isFormControlTarget(event.target)) return;
 
     // Check if user is zoomed in
     const isZoomed = comicReaderSwiper.zoom && comicReaderSwiper.zoom.scale > 1;
 
-    // If zoomed and CTRL held, pan the viewport
-    if (isZoomed && event.ctrlKey) {
-        if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(event.key)) {
+    // Pan the zoom window. Arrows need Shift or Ctrl, because unmodified arrows
+    // already mean page-turn (left/right) and zoom (up/down); W/A/S/D pan bare.
+    // Alt+arrow is browser history and Cmd/Ctrl+letter are browser shortcuts, so
+    // neither is claimed here.
+    const panDirection = PAN_KEYS[event.key];
+    if (panDirection) {
+        const isArrow = event.key.indexOf('Arrow') === 0;
+        const wantsPan = isArrow
+            ? ((event.shiftKey || event.ctrlKey) && !event.altKey && !event.metaKey)
+            : !(event.ctrlKey || event.altKey || event.metaKey);
+
+        if (wantsPan) {
+            // Swallowed even when not zoomed: a modified arrow must never fall
+            // through to a page turn, or an early pan press skips the page.
             event.preventDefault();
-            panZoomedView(event.key);
+            panZoomedViewByKey(panDirection);
             return;
         }
+        // A bare letter reaching here carries a browser modifier -- leave it be.
+        if (!isArrow) return;
+    }
+
+    // Re-centre after panning around, without losing the zoom level.
+    if ((event.key === '0' || event.key === 'Home') &&
+        !event.ctrlKey && !event.altKey && !event.metaKey && isZoomed) {
+        event.preventDefault();
+        recenterZoomedView();
+        return;
     }
 
     switch(event.key) {
@@ -789,7 +1015,22 @@ function initializeMousewheelHandler() {
         const isZoomed = comicReaderSwiper.zoom && comicReaderSwiper.zoom.scale > 1;
 
         if (isZoomed) {
-            // When zoomed, let Swiper handle panning (don't prevent default)
+            // Swiper's mousewheel module is off (see the config) and its zoom
+            // module ignores the wheel entirely, so nothing moves a zoomed page
+            // unless we do it here -- the wheel used to be dead while zoomed.
+            // Shift+wheel pans horizontally, matching normal page scrolling.
+            const slide = comicReaderSwiper.slides[comicReaderSwiper.activeIndex];
+            const pageW = slide ? slide.offsetWidth : window.innerWidth;
+            const pageH = slide ? slide.offsetHeight : window.innerHeight;
+            const deltaY = normalizeWheelDelta(event.deltaY, event.deltaMode, pageH);
+            const deltaX = normalizeWheelDelta(event.deltaX, event.deltaMode, pageW);
+
+            const dx = event.shiftKey ? -deltaY : -deltaX;
+            const dy = event.shiftKey ? 0 : -deltaY;
+
+            if (panZoomedView(dx, dy)) {
+                event.preventDefault();
+            }
             return;
         }
 
@@ -1053,6 +1294,7 @@ function closeComicReader() {
     // Reset dynamic background colors before hiding
     resetReaderBackgroundColor();
     pageEdgeColors = new Map();
+    hidePanHint();
 
     const modal = document.getElementById('comicReaderModal');
     modal.style.display = 'none';

--- a/templates/collection.html
+++ b/templates/collection.html
@@ -385,7 +385,7 @@
                 <button class="btn btn-sm btn-outline-light zoom-btn" id="zoomOutBtn" title="Zoom Out (Arrow Down)">
                     <i class="bi bi-zoom-out text-light"></i>
                 </button>
-                <button class="btn btn-sm btn-outline-light zoom-btn" id="zoomInBtn" title="Zoom In (Arrow Up)">
+                <button class="btn btn-sm btn-outline-light zoom-btn" id="zoomInBtn" title="Zoom In (Arrow Up). Pan with Shift+Arrows, WASD or scroll wheel; 0 to re-centre">
                     <i class="bi bi-zoom-in text-light"></i>
                 </button>
                 <select class="form-select form-select-sm page-selector" id="pageSelector">

--- a/templates/metadata_browser.html
+++ b/templates/metadata_browser.html
@@ -197,10 +197,10 @@
         </div>
         <div class="comic-reader-footer">
             <div class="comic-reader-footer-controls">
-                <button class="btn btn-sm btn-outline-light zoom-btn" id="zoomOutBtn" title="Zoom Out">
+                <button class="btn btn-sm btn-outline-light zoom-btn" id="zoomOutBtn" title="Zoom Out (Arrow Down)">
                     <i class="bi bi-zoom-out text-light"></i>
                 </button>
-                <button class="btn btn-sm btn-outline-light zoom-btn" id="zoomInBtn" title="Zoom In">
+                <button class="btn btn-sm btn-outline-light zoom-btn" id="zoomInBtn" title="Zoom In (Arrow Up). Pan with Shift+Arrows, WASD or scroll wheel; 0 to re-centre">
                     <i class="bi bi-zoom-in text-light"></i>
                 </button>
                 <select class="form-select form-select-sm page-selector" id="pageSelector">

--- a/templates/reading_list_view.html
+++ b/templates/reading_list_view.html
@@ -399,7 +399,7 @@
                 <button class="btn btn-sm btn-outline-light zoom-btn" id="zoomOutBtn" title="Zoom Out (Arrow Down)">
                     <i class="bi bi-zoom-out text-light"></i>
                 </button>
-                <button class="btn btn-sm btn-outline-light zoom-btn" id="zoomInBtn" title="Zoom In (Arrow Up)">
+                <button class="btn btn-sm btn-outline-light zoom-btn" id="zoomInBtn" title="Zoom In (Arrow Up). Pan with Shift+Arrows, WASD or scroll wheel; 0 to re-centre">
                     <i class="bi bi-zoom-in text-light"></i>
                 </button>
                 <select class="form-select form-select-sm page-selector" id="pageSelector">

--- a/templates/source_wall.html
+++ b/templates/source_wall.html
@@ -193,10 +193,10 @@
         </div>
         <div class="comic-reader-footer">
             <div class="comic-reader-footer-controls">
-                <button class="btn btn-sm btn-outline-light zoom-btn" id="zoomOutBtn" title="Zoom Out">
+                <button class="btn btn-sm btn-outline-light zoom-btn" id="zoomOutBtn" title="Zoom Out (Arrow Down)">
                     <i class="bi bi-zoom-out text-light"></i>
                 </button>
-                <button class="btn btn-sm btn-outline-light zoom-btn" id="zoomInBtn" title="Zoom In">
+                <button class="btn btn-sm btn-outline-light zoom-btn" id="zoomInBtn" title="Zoom In (Arrow Up). Pan with Shift+Arrows, WASD or scroll wheel; 0 to re-centre">
                     <i class="bi bi-zoom-in text-light"></i>
                 </button>
                 <select class="form-select form-select-sm page-selector" id="pageSelector">

--- a/tests/unit/test_reader_pan_controls.py
+++ b/tests/unit/test_reader_pan_controls.py
@@ -1,0 +1,203 @@
+"""Keyboard/wheel panning of the zoomed comic reader.
+
+Zooming always centres on the page, so without a way to move the zoom window
+the reader can only ever show the middle of the artwork. The pan controls live
+entirely in `static/js/reader.js`.
+
+There is no JS test runner in this repo, so these assert on the assets as text,
+following the precedent in test_source_search_ui.py and test_themes.py. They are
+a wiring guard, not a behaviour test, and they exist because of two mistakes
+that are easy to make again:
+
+- **The pan writer must never emit `scale()`.** Swiper splits the zoom across
+  two elements: `translate3d()` on the `.swiper-zoom-container` and `scale()` on
+  the `<img>` inside it. Writing a `scale()` of our own onto the container
+  multiplies against the image's, so the first pan press blows the page up to
+  scale-squared. That is precisely what the original implementation did.
+- **Bare arrows must keep their existing meaning.** Left/Right turn the page and
+  Up/Down zoom; panning is on modified arrows and W/A/S/D instead. A pan binding
+  that swallows an unmodified arrow silently breaks page turning.
+"""
+import os
+import re
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+STATIC_JS = os.path.join(REPO_ROOT, "static", "js")
+STATIC_CSS = os.path.join(REPO_ROOT, "static", "css")
+TEMPLATE_DIR = os.path.join(REPO_ROOT, "templates")
+
+# Every page that hosts the comic reader modal. The markup is duplicated across
+# all four, so anything documented in one has to be documented in all of them.
+READER_TEMPLATES = [
+    "collection.html",
+    "metadata_browser.html",
+    "reading_list_view.html",
+    "source_wall.html",
+]
+
+
+def read(path):
+    with open(path, encoding="utf-8") as f:
+        return f.read()
+
+
+def function_body(source, name):
+    """Slice one top-level `function name(...)` out of a JS file."""
+    start = source.index("function %s(" % name)
+    end = source.find("\nfunction ", start + 1)
+    return source[start:end if end != -1 else len(source)]
+
+
+@pytest.fixture(scope="module")
+def reader_js():
+    return read(os.path.join(STATIC_JS, "reader.js"))
+
+
+@pytest.fixture(scope="module")
+def reader_css():
+    return read(os.path.join(STATIC_CSS, "reader.css"))
+
+
+class TestPanTransform:
+
+    def test_pan_writer_never_emits_scale(self, reader_js):
+        # The <img> carries the scale; the container carries only the offset.
+        body = function_body(reader_js, "applyZoomPan")
+        assert "translate3d(" in body
+        assert "scale(" not in body, (
+            "applyZoomPan must not write scale() onto the zoom container -- it "
+            "multiplies against the scale Swiper puts on the <img>."
+        )
+
+    def test_pan_reads_its_offset_back_off_the_zoom_container(self, reader_js):
+        # Swiper re-reads the container's translate on touchstart, so reading and
+        # writing the same property is what keeps keyboard and drag panning in
+        # step instead of each jumping to the other's idea of the offset.
+        body = function_body(reader_js, "getZoomPanContext")
+        assert "translate3d" in body and "match(" in body
+
+    def test_pan_offset_is_clamped_to_the_scaled_image(self, reader_js):
+        body = function_body(reader_js, "applyZoomPan")
+        assert "Math.max(-ctx.maxX, Math.min(ctx.maxX" in body
+        assert "Math.max(-ctx.maxY, Math.min(ctx.maxY" in body
+
+    def test_pan_is_a_noop_until_actually_zoomed(self, reader_js):
+        body = function_body(reader_js, "getZoomPanContext")
+        assert "if (scale <= 1) return null;" in body
+
+
+class TestKeyBindings:
+
+    def test_wasd_and_arrows_are_both_pan_keys(self, reader_js):
+        pan_keys = reader_js[reader_js.index("const PAN_KEYS = {"):]
+        pan_keys = pan_keys[:pan_keys.index("};")]
+        for key in ("ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"):
+            assert key in pan_keys
+        for letter in ("w:", "W:", "a:", "A:", "s:", "S:", "d:", "D:"):
+            assert letter in pan_keys, "missing WASD pan key %r" % letter
+
+    def test_arrow_panning_requires_a_modifier(self, reader_js):
+        body = function_body(reader_js, "handleZoomKeyboard")
+        assert "event.shiftKey || event.ctrlKey" in body, (
+            "bare arrows must stay page-turn/zoom; panning needs Shift or Ctrl"
+        )
+
+    def test_browser_shortcut_modifiers_are_left_alone(self, reader_js):
+        # Alt+arrow is browser history and Cmd/Ctrl+letter are browser shortcuts.
+        body = function_body(reader_js, "handleZoomKeyboard")
+        assert "!event.altKey && !event.metaKey" in body
+        assert "!(event.ctrlKey || event.altKey || event.metaKey)" in body
+
+    def test_unmodified_arrows_still_turn_pages_and_zoom(self, reader_js):
+        body = function_body(reader_js, "handleZoomKeyboard")
+        assert "stepZoom('in')" in body and "stepZoom('out')" in body
+        assert "slidePrev()" in body and "slideNext()" in body
+
+    def test_recentre_key_is_bound(self, reader_js):
+        body = function_body(reader_js, "handleZoomKeyboard")
+        assert "'0'" in body and "'Home'" in body
+        assert "recenterZoomedView()" in body
+
+    def test_form_controls_keep_their_own_keys(self, reader_js):
+        # The reader binds on `document`, and its footer holds a <select>.
+        # Without this guard, W/A/S/D would eat the page selector's typeahead
+        # and Space would stop it opening.
+        assert "function _isFormControlTarget(" in reader_js
+        for handler in ("handleZoomKeyboard", "handleComicReaderKeydown"):
+            body = function_body(reader_js, handler)
+            assert "_isFormControlTarget(" in body, (
+                "%s must skip keys aimed at a form control" % handler
+            )
+
+
+class TestWheelPanning:
+
+    def test_wheel_pans_the_page_while_zoomed(self, reader_js):
+        # Swiper's mousewheel module is disabled and its zoom module ignores the
+        # wheel, so the wheel was simply dead once the reader was zoomed in.
+        body = function_body(reader_js, "initializeMousewheelHandler")
+        assert "panZoomedView(" in body
+        assert "event.shiftKey" in body, "Shift+wheel should pan horizontally"
+
+    def test_wheel_deltas_are_normalised_to_pixels(self, reader_js):
+        # Firefox reports lines (deltaMode 1); untranslated, a delta of 3 reads
+        # as a 3px pan and the wheel feels dead.
+        assert "function normalizeWheelDelta(" in reader_js
+        body = function_body(reader_js, "initializeMousewheelHandler")
+        assert "normalizeWheelDelta(" in body
+
+    def test_page_turning_by_wheel_survives_at_1x(self, reader_js):
+        body = function_body(reader_js, "initializeMousewheelHandler")
+        assert "slideNext()" in body and "slidePrev()" in body
+
+
+class TestPanHint:
+
+    def test_hint_is_built_in_js_not_markup(self, reader_js):
+        # The reader modal is duplicated across four templates; building the
+        # hint here is what stops those copies drifting.
+        assert "function ensurePanHintElement(" in reader_js
+        assert "reader-pan-hint" in reader_js
+        for name in READER_TEMPLATES:
+            html = read(os.path.join(TEMPLATE_DIR, name))
+            assert "reader-pan-hint" not in html, (
+                "%s should not hand-roll the pan hint" % name
+            )
+
+    def test_hint_is_styled(self, reader_css):
+        assert ".reader-pan-hint" in reader_css
+        assert ".reader-pan-hint.visible" in reader_css
+
+    def test_hint_stops_nagging_after_a_few_showings(self, reader_js):
+        assert "PAN_HINT_MAX_SHOWS" in reader_js
+        body = function_body(reader_js, "maybeShowPanHint")
+        assert "seen >= PAN_HINT_MAX_SHOWS" in body
+        # Blocked storage (private mode) must not break zooming.
+        assert "try {" in body and "catch" in body
+
+    def test_hint_is_skipped_on_touch_layouts(self, reader_js):
+        body = function_body(reader_js, "maybeShowPanHint")
+        assert "isMobileOrTablet()" in body
+
+
+class TestTooltipsDocumentThePanKeys:
+
+    @pytest.mark.parametrize("name", READER_TEMPLATES)
+    def test_zoom_in_button_documents_panning(self, name):
+        html = read(os.path.join(TEMPLATE_DIR, name))
+        match = re.search(r'id="zoomInBtn"[^>]*title="([^"]*)"', html)
+        assert match, "%s has no titled zoom-in button" % name
+        title = match.group(1)
+        assert "Shift+Arrows" in title and "WASD" in title, (
+            "%s: the zoom-in tooltip is the only place the pan keys are "
+            "advertised once the hint stops showing (got %r)" % (name, title)
+        )
+
+    @pytest.mark.parametrize("name", READER_TEMPLATES)
+    def test_zoom_out_button_documents_its_key(self, name):
+        html = read(os.path.join(TEMPLATE_DIR, name))
+        match = re.search(r'id="zoomOutBtn"[^>]*title="([^"]*)"', html)
+        assert match, "%s has no titled zoom-out button" % name
+        assert "Arrow Down" in match.group(1)


### PR DESCRIPTION
Zooming the comic reader always centres on the page, so a zoomed-in page could only ever show the middle of the artwork. This adds controls to move the zoom window.

## Controls (while zoomed in)

| Keys | Action |
|---|---|
| `Shift`+arrows or `Ctrl`+arrows | Pan the zoom window |
| `W` `A` `S` `D` | Pan (no modifier) |
| `0` or `Home` | Re-centre, keeping the zoom level |
| Wheel / `Shift`+wheel | Pan vertically / horizontally |

Existing bindings are untouched: bare ←/→ turn pages, bare ↑/↓ zoom, Space advances. Arrows need a modifier to pan precisely so they can't steal page-turn or zoom; W/A/S/D are free keys, so they pan bare. `Alt`+arrow (browser history) and `Ctrl`/`Cmd`+letter (browser shortcuts) are deliberately not claimed.

A press moves 20% of the visible page, so the step stays useful at 3x — the old fixed 50px was imperceptible there.

## Two bugs fixed on the way

**Ctrl+arrow panning blew the page up.** Swiper splits the zoom across two elements: `translate3d()` on the `.swiper-zoom-container`, `scale()` on the `<img>` inside it. The old writer put `translate3d(...) scale(N)` on the *container*, which multiplies against the image's scale — one press at 1.67x jumped to ~2.8x. Verified against the actual Swiper 11 bundle rather than from memory. The writer now emits translate only, and because Swiper re-reads that translate off the DOM on touchstart, keyboard panning and drag panning stay in step instead of snapping to each other's offset.

**The wheel was dead while zoomed.** The handler returned early "to let Swiper handle panning", but Swiper's mousewheel module is disabled in our config and its zoom module ignores the wheel, so nothing happened. It now pans, with Firefox's line-mode deltas normalised to pixels.

## Also

- Keys aimed at a form control are left alone. The reader binds on `document` and its footer holds a `<select>`, so W/A/S/D would have eaten its typeahead — and Space was already stopping it opening.
- A hint pill fades in the first time a page is zoomed, hides as soon as the user pans, and stops appearing after three sessions. It's built in JS rather than markup because the reader modal is duplicated across `collection.html`, `metadata_browser.html`, `reading_list_view.html` and `source_wall.html`. Their zoom-button tooltips are updated and made consistent — two had lost their key hints.
- Replaced a dead `.comic-reader-zoom-hint` CSS block (no markup referenced it) with the styles for the new hint.

## Verification

- Drove the handlers in a stubbed DOM: 25 checks covering bounds clamping, the no-`scale()` invariant, every modifier combination, and that bare arrows still page-turn/zoom.
- `tests/unit/test_reader_pan_controls.py` (25 tests) guards the wiring as text, in the style of `test_source_search_ui.py`, since there's no JS runner in the repo.
- Full suite: **4559 passed, 7 skipped** (the documented POSIX/Windows skips).

## Not included

Swiper 11 has a `zoom.panOnMouseMove` option that pans as the mouse moves, with no click. It's a one-line config change, but it makes the page drift under an idle cursor, so it's left off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BYB2bF4mdCDQXB4wya4PfS
