### PR TITLE
feat: add INDUCKS as a metadata provider for Disney comics

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -107,6 +107,7 @@ CLU is a comic metadata editor as well as a file tool. Metadata is written to `C
 | **ComicVine** | Via the ComicVine API, or from a local offline SQLite database |
 | **Grand Comics Database (GCD)** | Optional local SQLite database with fuzzy title matching |
 | **GCD API** | Hosted GCD access |
+| **[INDUCKS](docs/inducks-provider.md)** | Optional local SQLite database of Disney comics worldwide |
 | **AniList** | Manga metadata |
 | **MangaDex** | Manga metadata |
 | **MangaUpdates** | Manga metadata |

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Map your main library to `/data`. Additional libraries can be mapped to any path
 | [Metron](https://metron.cloud/) | Comic metadata, series, story arcs, weekly releases |
 | [ComicVine](https://comicvine.gamespot.com/api/) | Comic metadata via API, or a [local offline database](https://clucomics.org/features/local-databases/comicvine/) |
 | [Grand Comics Database](https://clucomics.org/features/local-databases/gcd/) | Optional local SQLite metadata database |
+| [INDUCKS](docs/inducks-provider.md) | Optional local SQLite database of Disney comics worldwide |
 | AniList / MangaDex / MangaUpdates | Manga metadata |
 | Bedetheque | Bandes dessinées (European comics) metadata |
 | [Komga](https://komga.org/) | Optional reading-history sync |

--- a/core/database.py
+++ b/core/database.py
@@ -12419,6 +12419,12 @@ def invalidate_provider_client_caches() -> None:
         invalidate_session_cache()
     except Exception as e:
         app_logger.warning(f"Could not clear Metron session cache: {e}")
+    try:
+        from models.inducks import invalidate_inducks_table_cache
+
+        invalidate_inducks_table_cache()
+    except Exception as e:
+        app_logger.warning(f"Could not clear INDUCKS table cache: {e}")
 
 
 def get_provider_credentials(provider_type: str) -> Optional[dict]:

--- a/core/metadata_dates.py
+++ b/core/metadata_dates.py
@@ -79,7 +79,7 @@ _SERIES_YEAR_PROVIDERS = frozenset({
 # exempt until someone classifies it -- the wrong default here rejects real
 # matches, so an unknown provider gets the benefit of the doubt.
 _ISSUE_YEAR_PROVIDERS = frozenset({
-    "comicvine", "comicvine_sqlite", "gcd", "gcd_api", "metron",
+    "comicvine", "comicvine_sqlite", "gcd", "gcd_api", "metron", "inducks",
 })
 
 

--- a/core/metadata_dates.py
+++ b/core/metadata_dates.py
@@ -135,7 +135,8 @@ def date_check_tolerance() -> int:
     return value if value >= 0 else DEFAULT_TOLERANCE_YEARS
 
 
-def issue_year_from_filename(name: Optional[str]) -> Optional[int]:
+def issue_year_from_filename(name: Optional[str],
+                             issue_number: Optional[Any] = None) -> Optional[int]:
     """The publication year a filename claims, or None if it claims none.
 
     Distinct from ``extract_year_from_name`` in ``routes/metadata.py``, which
@@ -151,6 +152,16 @@ def issue_year_from_filename(name: Optional[str]) -> Optional[int]:
     Returns None when the filename names more than one distinct year: two
     candidates cannot disambiguate anything, and guessing between them is how a
     correct match gets rejected.
+
+    ``issue_number``, when given, exempts the one case where a four-digit
+    *issue* number reads as a year: Disney's Topolino runs past #3600, so a
+    bare "Topolino 2000.cbz" is both a plausible year and the issue number, and
+    only the caller -- which parsed the issue number separately -- can tell
+    them apart. The exemption applies only when the filename names exactly one
+    plausible year and it equals the issue number; a filename that also
+    carries a real year ("Topolino 1975 (1993).cbz") already has two distinct
+    candidates and stays unresolved on that ground alone, regardless of
+    ``issue_number``.
     """
     if not name:
         return None
@@ -163,7 +174,15 @@ def issue_year_from_filename(name: Optional[str]) -> Optional[int]:
 
     if len(plausible) != 1:
         return None
-    return plausible.pop()
+    year = plausible.pop()
+
+    if issue_number is not None:
+        try:
+            if int(str(issue_number).strip()) == year:
+                return None
+        except (TypeError, ValueError):
+            pass
+    return year
 
 
 def _year_of(issue_date: Any) -> Optional[int]:
@@ -209,17 +228,22 @@ def conflict_message(filename: str, filename_year: int, issue_date: Any) -> str:
     )
 
 
-def evaluate(filename: Optional[str], issue_date: Any) -> tuple:
+def evaluate(filename: Optional[str], issue_date: Any,
+            issue_number: Optional[Any] = None) -> tuple:
     """Convenience for call sites: ``(mode, conflicted, filename_year)``.
 
     Short-circuits entirely when the mode is 'off', so the disabled path costs
     one config read and does no parsing at all.
+
+    ``issue_number``, when the caller has one, is passed through to
+    ``issue_year_from_filename`` to exempt a filename year that is actually
+    the issue number -- see that function's docstring.
     """
     mode = date_check_mode()
     if mode == MODE_OFF:
         return MODE_OFF, False, None
 
-    filename_year = issue_year_from_filename(filename)
+    filename_year = issue_year_from_filename(filename, issue_number)
     conflicted = date_conflict(filename_year, issue_date)
     if conflicted:
         app_logger.info(conflict_message(filename, filename_year, issue_date))

--- a/docs/inducks-provider.md
+++ b/docs/inducks-provider.md
@@ -49,21 +49,57 @@ has them, so an Italian issue says Paperino rather than Donald Duck.
 
 `Notes` records the INDUCKS issue code, which is also what marks the file as already tagged.
 
-## Ambiguity is refused, not guessed
+## How a folder is matched to a publication
 
-Where a folder name resolves to more than one publication, the provider returns all of them and
-tags nothing. A folder called `Topolino` matches eleven Italian publications — the libretto, the
-giornale, and nine reprint runs — and picking one arbitrarily is how a library ends up confidently
-mislabelled. Such a folder goes to the review queue, where you choose.
+Two things make this harder than it is for the other providers, and they pull in opposite
+directions.
 
-A year in the folder name settles the case where two runs share an identical title and started in
-different years, because that is evidence rather than a tiebreak. It does not help where the
-competing runs are reprints of each other; those need a manual choice.
+A Disney title names several runs at once: eleven Italian publications reduce to the name
+`Topolino` — the libretto, the giornale, and nine reprint runs — so the title alone can never
+identify one. At the same time these folders are very often named after a slice of a run rather
+than after the publication: `Topolino anno 1975`, `Anno 1986 vol 1571-1622`, `Albo d'oro v2`. So
+the name has to be read loosely, and then the result has to be narrowed strictly.
+
+**Finding candidates.** Three names are tried in turn, and the first that matches anything at all
+wins: the folder name; the folder name with a trailing run marker removed (`anno 1975`,
+`vol 1571-1622`, `v2`, `Repack`); and the series name CLU parses out of the filename itself.
+Within one name, the title is looked up as spelled, then with a trailing parenthetical qualifier
+removed, then with a series ordinal normalised (`II Serie` and `2a serie` both mean
+`Seconda Serie`), and finally — only if nothing else matched — on its significant words with
+Italian articles and prepositions ignored, so `Le grandi storie di Walt Disney - L'opera omnia di
+Romano Scarpa` reaches what INDUCKS calls `Le grandi storie Disney - L'opera omnia di Romano
+Scarpa`.
+
+A name that spells out a qualifier always wins over the bare one: a folder called
+`Topolino (giornale)` is never answered by the publication merely called `Topolino`.
+
+**Narrowing them.** The issue number then decides between whatever the name produced. Of the
+eleven publications called `Topolino`, only `it/TL` has an issue 1500 at all — so the loose name
+is safe, because the narrowing is evidence the caller already has rather than a preference. If
+more than one publication still holds that number, the year in the filename is compared with that
+issue's own date, and after that an exactly-matching title beats a qualifier-stripped one.
+
+This is also what lets a run continue into its second series: `Super Almanacco Paperino` names two
+publications, and issues 1–17 come from one while 18 onwards come from the other. Both are
+offered, and the issue number picks correctly for each file.
+
+**Ambiguity is refused, not guessed.** If more than one publication survives all of that, nothing
+is written and the folder goes to the review queue, where you choose. Picking one arbitrarily is
+how a library ends up confidently mislabelled. Equally, if no publication holds the issue number,
+the provider returns nothing and the next provider gets its turn — better than answering from the
+wrong run.
 
 ## The date check
 
 INDUCKS carries a real per-issue publication date, so the [metadata date
-check](metadata-date-check.md) applies to it. With `date_check_mode` set to `enforce`, a match
+check](metadata-date-check.md) applies to it.
+
+One caveat specific to this material: a comic whose issue number is a bare four-digit number in
+the 1900–2099 range — `Topolino 1904.cbz` — has that number read as a publication year, so the
+check sees a disagreement that is not there. Under `enforce` those files are rejected. Either
+leave the check on `log` for a folder of high-numbered issues, or name the files with the year as
+well, which resolves it.
+ With `date_check_mode` set to `enforce`, a match
 whose issue date contradicts the filename year is dropped and the next provider gets its turn.
 This is worth turning on for a Disney library specifically: short, common, heavily reused titles
 are exactly where the other providers produce confident wrong answers.

--- a/docs/inducks-provider.md
+++ b/docs/inducks-provider.md
@@ -1,0 +1,75 @@
+# INDUCKS provider
+
+[INDUCKS](https://inducks.org/) is the reference index of Disney comics worldwide. It is the one
+source that covers this material properly, because a Disney issue is an anthology of a dozen
+unrelated stories and the general-purpose databases model it as a single book.
+
+Like the GCD and local ComicVine providers, it reads a SQLite database file you build and place on
+disk. CLU never downloads or builds it, and opens it read-only.
+
+## What it covers
+
+The current dump holds 84 countries, 7,310 publications, 259,785 issues and just over two million
+story entries. Disney publishing is overwhelmingly European and South American: by issues indexed
+the largest countries are Sweden, Italy, the Netherlands, Norway, France, Germany, Finland and
+Brazil, with the US ninth.
+
+Every publication records its country and language, so `it/TL` unambiguously identifies the Italian
+*Topolino* and `se/KA` the Swedish *Kalle Anka* — the disambiguation no other provider can offer
+for a title that exists in twenty countries at once.
+
+## Setting it up
+
+1. Build the database. INDUCKS publishes its whole database as a tarball of `.isv` files at a
+   stable URL; importing it produces roughly 700 MB of SQLite.
+2. Put the file on a path CLU can see, for example `/config/inducks.db`.
+3. In **Config → Metadata Providers → INDUCKS (Disney)**, enter that path and save.
+
+### Publication countries
+
+The same title is published in dozens of countries, so an unfiltered search is ambiguous for
+nearly every Disney name there is. The **Publication Countries** field on the provider card is a
+comma-separated list of INDUCKS country codes, stored as the `inducks_countries` preference.
+
+| Preference | Default | Meaning |
+| --- | --- | --- |
+| `inducks_countries` | `us` | Which countries' publications a lookup may match |
+
+Set it to the countries your library actually holds — `it` for an Italian collection, `it,fr,se`
+for several. The default of `us` keeps a freshly configured provider harmless rather than
+confidently foreign.
+
+## What it writes
+
+The album is the unit. `Series` and `Number` name the album, `Summary` holds its table of contents
+one line per story, and credits and characters are merged across the stories in first-appearance
+order — covers and illustrations excluded, since a cover artist is not the penciller of the book.
+`LanguageISO` comes from the publication, and character names are the localised ones where INDUCKS
+has them, so an Italian issue says Paperino rather than Donald Duck.
+
+`Notes` records the INDUCKS issue code, which is also what marks the file as already tagged.
+
+## Ambiguity is refused, not guessed
+
+Where a folder name resolves to more than one publication, the provider returns all of them and
+tags nothing. A folder called `Topolino` matches eleven Italian publications — the libretto, the
+giornale, and nine reprint runs — and picking one arbitrarily is how a library ends up confidently
+mislabelled. Such a folder goes to the review queue, where you choose.
+
+A year in the folder name settles the case where two runs share an identical title and started in
+different years, because that is evidence rather than a tiebreak. It does not help where the
+competing runs are reprints of each other; those need a manual choice.
+
+## The date check
+
+INDUCKS carries a real per-issue publication date, so the [metadata date
+check](metadata-date-check.md) applies to it. With `date_check_mode` set to `enforce`, a match
+whose issue date contradicts the filename year is dropped and the next provider gets its turn.
+This is worth turning on for a Disney library specifically: short, common, heavily reused titles
+are exactly where the other providers produce confident wrong answers.
+
+## Ordering
+
+INDUCKS is more specialised than the other providers and is registered after them, so it changes
+nothing for a library with no Disney material in it. For a library that is mostly Disney, order it
+ahead of GCD in the per-library provider settings.

--- a/models/inducks.py
+++ b/models/inducks.py
@@ -1,0 +1,849 @@
+"""
+INDUCKS integration for Disney comic metadata retrieval.
+
+Reads a user-provided SQLite build of the INDUCKS database
+(https://inducks.org/), the reference index of Disney comics worldwide. Like
+the GCD and ComicVine SQLite providers, CLU never downloads or builds the file:
+the user points a setting at it and CLU opens it read-only.
+
+Two things make this material different from what the other providers handle,
+and both shape the code below.
+
+A Disney issue is an *anthology*: one album holds a dozen unrelated stories,
+each with its own credits and cast. INDUCKS models that faithfully — issue ->
+entry -> story version -> jobs/appearances — so the metadata has to be
+flattened back to the one-book-one-record shape ComicInfo assumes. See
+``_build_comicinfo`` for the mapping chosen and why.
+
+The same title is also published in dozens of countries: ``it/TL`` is the
+Italian *Topolino* and ``se/KA`` the Swedish *Kalle Anka*. Searching without a
+country filter is therefore ambiguous by construction, which is what
+``get_configured_countries`` exists to prevent.
+"""
+import os
+import sqlite3
+import unicodedata
+from datetime import datetime
+from typing import Optional, Dict, Any, List, Set
+
+from core.app_logging import app_logger
+
+# =============================================================================
+# Constants
+# =============================================================================
+
+# Every table CLU reads. All of them are required rather than split into core
+# and optional sets the way models.gcd does it, and deliberately so: the GCD
+# distinction exists because comics.org periodically publishes dumps with tables
+# missing, whereas INDUCKS ships one tarball containing the whole database. A
+# build missing any of these is a broken build, and saying so through
+# test_connection is more useful than silently dropping every credit in the
+# library.
+INDUCKS_CORE_TABLES = frozenset({
+    'inducks_publication', 'inducks_issue', 'inducks_issuedate',
+    'inducks_entry', 'inducks_storyversion', 'inducks_story',
+    'inducks_storyjob', 'inducks_person', 'inducks_publisher',
+    'inducks_publishingjob', 'inducks_character', 'inducks_charactername',
+    'inducks_appearance',
+})
+
+# ``inducks_storyjob.plotwritartink`` is a single character naming the job.
+# "r" also occurs, for retouching, and has no ComicInfo equivalent.
+_JOB_WRITER = ('p', 'w')
+_JOB_PENCILLER = ('a',)
+_JOB_INKER = ('i',)
+
+# ``inducks_storyversion.kind`` codes that are actual comic or text stories, as
+# opposed to covers ("c"), illustrations ("i") and other filler. Only these
+# contribute to the table of contents and the merged credits.
+STORY_KINDS = frozenset({'n', 't'})
+
+# INDUCKS writes this in a date column to mean "unknown" rather than leaving it
+# empty, so it has to be filtered explicitly everywhere a date is read. It is
+# also why the start-year aggregate cannot be a bare MIN() — see
+# ``_start_year_and_count``.
+_UNKNOWN_DATE_PREFIX = '9999'
+
+# Cached set of INDUCKS tables actually present in the connected database.
+_AVAILABLE_TABLES_CACHE: Optional[Set[str]] = None
+
+
+# =============================================================================
+# Helper Functions
+# =============================================================================
+
+def normalize_title(text: str) -> str:
+    """Fold a title down to a comparable key.
+
+    Accents, punctuation and case vary between filenames and INDUCKS titles, so
+    matching happens on a stripped-down form: "Zio Paperone" and
+    "zio  paperone!" both become "zio paperone".
+
+    Deliberately not ``models.gcd.normalize_title``: that one drops every
+    non-ASCII character, which for this material would fold "Paperinik" and
+    "Paperìnik" together while turning a Nordic title into a row of spaces.
+    """
+    decomposed = unicodedata.normalize('NFKD', str(text or '').lower())
+    stripped = ''.join(c for c in decomposed if not unicodedata.combining(c))
+    kept = ''.join(c if c.isalnum() else ' ' for c in stripped)
+    return ' '.join(kept.split())
+
+
+def strip_qualifier(title: str) -> str:
+    """Remove a trailing parenthetical from a publication title.
+
+    INDUCKS disambiguates reused titles that way — "Topolino (libretto)" — but
+    the bare name is what a filename usually carries.
+    """
+    head = str(title or '').split('(')[0].strip()
+    return head or str(title or '').strip()
+
+
+def _dict_factory(cursor, row):
+    """Row factory returning plain dicts, matching models.gcd."""
+    return {col[0]: row[idx] for idx, col in enumerate(cursor.description)}
+
+
+# =============================================================================
+# Database Connection
+# =============================================================================
+
+def _get_saved_credentials() -> Optional[Dict[str, Any]]:
+    """Get INDUCKS credentials saved via the UI."""
+    try:
+        from core.database import get_provider_credentials
+        return get_provider_credentials('inducks')
+    except Exception:
+        return None
+
+
+def get_connection_params() -> Optional[Dict[str, Any]]:
+    """
+    Get INDUCKS SQLite connection parameters.
+
+    Checks saved credentials first, then falls back to the
+    INDUCKS_DATABASE_PATH environment variable.
+
+    Returns:
+        Dict with database_path, or None if not configured
+    """
+    saved_creds = _get_saved_credentials()
+    if saved_creds and saved_creds.get('database_path'):
+        return {'database_path': saved_creds.get('database_path')}
+
+    env_path = os.environ.get('INDUCKS_DATABASE_PATH')
+    if env_path:
+        return {'database_path': env_path}
+
+    return None
+
+
+def is_database_available() -> bool:
+    """Check whether a configured INDUCKS SQLite file exists on disk."""
+    params = get_connection_params()
+    path = params.get('database_path') if params else None
+    return bool(path and os.path.exists(path))
+
+
+def check_database_status() -> Dict[str, Any]:
+    """Check if the INDUCKS SQLite database is configured and present on disk."""
+    try:
+        params = get_connection_params()
+        path = params.get('database_path') if params else None
+        available = bool(path and os.path.exists(path))
+
+        return {
+            "inducks_available": available,
+            "inducks_path_configured": bool(path),
+        }
+    except Exception as e:
+        return {
+            "inducks_available": False,
+            "inducks_path_configured": False,
+            "error": str(e)
+        }
+
+
+def get_connection():
+    """
+    Open and return a read-only SQLite connection to the INDUCKS database.
+
+    Returns:
+        sqlite3.Connection (dict rows) or None on failure
+    """
+    try:
+        params = get_connection_params()
+        if not params or not params.get('database_path'):
+            app_logger.error("INDUCKS database not configured (no saved path or INDUCKS_DATABASE_PATH)")
+            return None
+
+        path = params['database_path']
+        if not os.path.exists(path):
+            app_logger.error(f"INDUCKS database file not found: {path}")
+            return None
+
+        # Read-only URI: never creates an empty DB on a bad path and never
+        # writes -wal/-shm/journal files next to the (700 MB) build.
+        conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+        conn.row_factory = _dict_factory
+        return conn
+    except sqlite3.Error as e:
+        app_logger.error(f"Failed to open INDUCKS SQLite database: {e}")
+        return None
+    except Exception as e:
+        app_logger.error(f"Failed to open INDUCKS SQLite database: {e}")
+        return None
+
+
+# =============================================================================
+# Table Availability
+# =============================================================================
+
+def get_available_inducks_tables(conn=None, *, force_refresh: bool = False) -> Set[str]:
+    """Return which of the required INDUCKS tables are present in the database."""
+    global _AVAILABLE_TABLES_CACHE
+
+    if _AVAILABLE_TABLES_CACHE is not None and not force_refresh:
+        return _AVAILABLE_TABLES_CACHE
+
+    own_conn = conn is None
+    if own_conn:
+        conn = get_connection()
+    if not conn:
+        return set()
+
+    try:
+        cursor = conn.cursor()
+        cursor.execute("SELECT name FROM sqlite_master WHERE type = 'table'")
+        present = {row['name'] for row in cursor.fetchall()}
+        cursor.close()
+        available = INDUCKS_CORE_TABLES & present
+        _AVAILABLE_TABLES_CACHE = available
+        missing = INDUCKS_CORE_TABLES - available
+        if missing:
+            app_logger.warning(f"INDUCKS database is missing tables: {sorted(missing)}")
+        return available
+    except Exception as e:
+        app_logger.error(f"Could not inspect INDUCKS tables: {e}")
+        return set()
+    finally:
+        if own_conn:
+            conn.close()
+
+
+def invalidate_inducks_table_cache() -> None:
+    """Drop the cached table set, after the configured path changes."""
+    global _AVAILABLE_TABLES_CACHE
+    _AVAILABLE_TABLES_CACHE = None
+
+
+# =============================================================================
+# Database Statistics
+# =============================================================================
+
+def get_database_stats() -> Optional[Dict[str, Any]]:
+    """Row counts for the settings page, or None if the database is unusable."""
+    conn = get_connection()
+    if not conn:
+        return None
+    try:
+        cursor = conn.cursor()
+        stats: Dict[str, Any] = {}
+        for label, table in (
+            ('publications', 'inducks_publication'),
+            ('issues', 'inducks_issue'),
+            ('entries', 'inducks_entry'),
+        ):
+            try:
+                cursor.execute(f"SELECT COUNT(*) AS n FROM {table}")
+                stats[label] = cursor.fetchone()['n']
+            except sqlite3.Error:
+                stats[label] = None
+        cursor.execute("SELECT COUNT(DISTINCT countrycode) AS n FROM inducks_publication")
+        stats['countries'] = cursor.fetchone()['n']
+        cursor.close()
+        return stats
+    except Exception as e:
+        app_logger.error(f"INDUCKS get_database_stats failed: {e}")
+        return None
+    finally:
+        conn.close()
+
+
+# =============================================================================
+# Preferences
+# =============================================================================
+
+def get_configured_countries() -> List[str]:
+    """Country codes to filter INDUCKS publications by, from the user preference.
+
+    The same title is published in dozens of countries, so an unfiltered search
+    is ambiguous for nearly every Disney name there is. Mirrors
+    ``models.gcd.get_configured_languages``: one accessor, read at call time, so
+    that automatic and manual lookups can never drift apart.
+
+    Falls back to ``['us']``, which keeps a freshly configured provider harmless
+    rather than confidently Italian.
+    """
+    try:
+        from core.database import get_user_preference
+        raw = get_user_preference('inducks_countries', default='us')
+    except Exception as e:
+        app_logger.warning(f"Could not read inducks_countries preference: {e}")
+        return ['us']
+
+    codes = [code.strip().lower() for code in str(raw or '').split(',') if code.strip()]
+    return codes or ['us']
+
+
+# =============================================================================
+# Series Search
+# =============================================================================
+
+def _publication_rows(conn, country_codes: List[str]) -> List[Dict[str, Any]]:
+    """Every titled publication in the given countries."""
+    placeholders = ','.join('?' for _ in country_codes)
+    cursor = conn.cursor()
+    cursor.execute(
+        "SELECT publicationcode, title, countrycode, languagecode "
+        "FROM inducks_publication "
+        f"WHERE countrycode IN ({placeholders}) AND title IS NOT NULL AND title <> ''",
+        tuple(country_codes),
+    )
+    rows = cursor.fetchall()
+    cursor.close()
+    return rows
+
+
+def _colliding_stripped_titles(conn) -> Set[str]:
+    """Normalised qualifier-stripped titles claimed by more than one publication.
+
+    Computed across every country, not just the configured ones: the qualifier
+    is what tells "Topolino (libretto)" from "Topolino (giornale)", and dropping
+    it from the series name would make a reader merge two unrelated runs into
+    one shelf entry.
+    """
+    counts: Dict[str, int] = {}
+    cursor = conn.cursor()
+    cursor.execute("SELECT title FROM inducks_publication WHERE title IS NOT NULL AND title <> ''")
+    for row in cursor.fetchall():
+        key = normalize_title(strip_qualifier(row['title']))
+        if key:
+            counts[key] = counts.get(key, 0) + 1
+    cursor.close()
+    return {key for key, count in counts.items() if count > 1}
+
+
+def series_name_for(conn, title: str, colliding: Optional[Set[str]] = None) -> str:
+    """The name to write into ComicInfo's Series field.
+
+    The parenthetical qualifier is dropped, so "Topolino (libretto)" becomes
+    plain "Topolino" — except where dropping it would collide with another
+    publication, in which case the qualifier is what keeps two unrelated runs
+    apart and is kept.
+
+    ``colliding`` lets a caller naming several publications compute the
+    collision set once instead of rescanning the publication table per title.
+    """
+    stripped = strip_qualifier(title)
+    if stripped == title:
+        return title
+    if colliding is None:
+        colliding = _colliding_stripped_titles(conn)
+    return title if normalize_title(stripped) in colliding else stripped
+
+
+def _search_keys(series_name: str) -> List[str]:
+    """Lookup keys for a series name, most specific first."""
+    keys: List[str] = []
+    for variant in (series_name, strip_qualifier(series_name)):
+        key = normalize_title(variant)
+        if key and key not in keys:
+            keys.append(key)
+    return keys
+
+
+def _start_year_and_count(conn, publicationcode: str) -> Dict[str, Any]:
+    """The year a publication began, and how many issues it has.
+
+    ``inducks_publication`` has no start-year column, so the year has to be
+    derived from the issues — and the obvious ``MIN(SUBSTR(oldestdate, 1, 4))``
+    is wrong twice over. ``oldestdate`` is frequently the empty string, which
+    sorts before every real date, and INDUCKS writes ``9999-12-31`` for an
+    unknown one. Both have to become NULL before MIN() sees them.
+
+    This is not a cosmetic difference. Measured over the 664 Italian
+    publications that have issues, the naive form yields a blank year for 44 of
+    them and the corrected form for 13 — and among the 31 it recovers is
+    ``it/TL``, *Topolino (libretto)*, whose real start year is 1949.
+
+    The year matters more than it looks: ``core.bulk_metadata._years_match``
+    refuses to auto-accept a series whose year is None, so a publication with no
+    derivable start year goes to the review queue on every file forever.
+    """
+    cursor = conn.cursor()
+    cursor.execute(
+        "SELECT MIN(NULLIF(NULLIF(SUBSTR(oldestdate, 1, 4), ''), ?)) AS year_began, "
+        "       COUNT(*) AS issue_count "
+        "FROM inducks_issue WHERE publicationcode = ?",
+        (_UNKNOWN_DATE_PREFIX, publicationcode),
+    )
+    row = cursor.fetchone() or {}
+    cursor.close()
+
+    year_began = None
+    raw_year = row.get('year_began')
+    if raw_year:
+        try:
+            year_began = int(raw_year)
+        except (TypeError, ValueError):
+            year_began = None
+
+    return {'year_began': year_began, 'issue_count': row.get('issue_count') or 0}
+
+
+def search_series(series_name: str, year: Optional[int] = None,
+                  country_codes: Optional[List[str]] = None) -> List[Dict[str, Any]]:
+    """Find the INDUCKS publications a series name could refer to.
+
+    Returns *every* publication the name resolves to rather than picking one.
+    Disney titles collide constantly — "Almanacco Topolino" is a publication in
+    its own right and a qualifier-stripped form of two others — and choosing
+    arbitrarily between them is how a library ends up confidently mislabelled.
+    Callers that need a single answer should require exactly one result; the
+    batch path does, and an ambiguous name goes to the review queue instead.
+
+    The name is looked up in two indexes, exact titles first and
+    qualifier-stripped titles second, each fully resolved before falling back to
+    the next key. That ordering is what stops a file named "Topolino
+    (giornale)" being answered by the publication merely called "Topolino".
+
+    ``year`` orders otherwise-equal candidates by closeness to the year the
+    publication began; it never filters, because a folder year that disagrees is
+    exactly the case the date check exists to catch.
+
+    Args:
+        series_name: Name of the series to search for
+        year: Optional year parsed from the folder or filename
+        country_codes: Optional country filter. Defaults to the configured
+            ``inducks_countries`` preference.
+
+    Returns:
+        List of publication dicts, best first. Empty when nothing matched.
+    """
+    if not series_name or not str(series_name).strip():
+        return []
+
+    if country_codes is None:
+        country_codes = get_configured_countries()
+    if not country_codes:
+        return []
+
+    conn = get_connection()
+    if not conn:
+        return []
+
+    try:
+        exact: Dict[str, List[Dict[str, Any]]] = {}
+        stripped: Dict[str, List[Dict[str, Any]]] = {}
+
+        for row in _publication_rows(conn, country_codes):
+            title = row['title']
+            for index, variant in ((exact, title), (stripped, strip_qualifier(title))):
+                key = normalize_title(variant)
+                if key:
+                    index.setdefault(key, []).append(row)
+
+        matches: List[Dict[str, Any]] = []
+        for key in _search_keys(series_name):
+            for index in (exact, stripped):
+                if index.get(key):
+                    matches = index[key]
+                    break
+            if matches:
+                break
+
+        if not matches:
+            return []
+
+        colliding = _colliding_stripped_titles(conn)
+        results = []
+        for row in matches:
+            derived = _start_year_and_count(conn, row['publicationcode'])
+            results.append({
+                'id': row['publicationcode'],
+                'name': series_name_for(conn, row['title'], colliding),
+                'title': row['title'],
+                'year_began': derived['year_began'],
+                'issue_count': derived['issue_count'],
+                'country_code': row['countrycode'] or '',
+                'language_code': row['languagecode'] or '',
+            })
+
+        # Closest start year first when the caller supplied one, so a name that
+        # names two runs of the same publication is at least offered in a useful
+        # order. Undated candidates sort last; they can never auto-accept.
+        if year:
+            results.sort(key=lambda r: abs(r['year_began'] - year) if r['year_began'] else 10_000)
+        else:
+            results.sort(key=lambda r: (r['year_began'] is None, -(r['issue_count'] or 0)))
+
+        return results
+    except sqlite3.Error as db_error:
+        app_logger.error(f"Database error in INDUCKS search_series: {db_error}")
+        return []
+    except Exception as e:
+        app_logger.error(f"Exception in INDUCKS search_series: {e}")
+        return []
+    finally:
+        conn.close()
+
+
+def get_series(publicationcode: str) -> Optional[Dict[str, Any]]:
+    """One publication by its INDUCKS code, in the shape search_series returns."""
+    if not publicationcode:
+        return None
+
+    conn = get_connection()
+    if not conn:
+        return None
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT publicationcode, title, countrycode, languagecode "
+            "FROM inducks_publication WHERE publicationcode = ?",
+            (publicationcode,),
+        )
+        row = cursor.fetchone()
+        cursor.close()
+        if not row:
+            return None
+
+        derived = _start_year_and_count(conn, publicationcode)
+        return {
+            'id': row['publicationcode'],
+            'name': series_name_for(conn, row['title'] or ''),
+            'title': row['title'] or '',
+            'year_began': derived['year_began'],
+            'issue_count': derived['issue_count'],
+            'country_code': row['countrycode'] or '',
+            'language_code': row['languagecode'] or '',
+        }
+    except Exception as e:
+        app_logger.error(f"INDUCKS get_series failed: {e}")
+        return None
+    finally:
+        conn.close()
+
+
+def get_issues(publicationcode: str) -> List[Dict[str, Any]]:
+    """Every issue of a publication, oldest first."""
+    if not publicationcode:
+        return []
+
+    conn = get_connection()
+    if not conn:
+        return []
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT issuecode, issuenumber, title, "
+            "       NULLIF(NULLIF(oldestdate, ''), '9999-12-31') AS oldestdate "
+            "FROM inducks_issue WHERE publicationcode = ? "
+            "ORDER BY CASE WHEN issuenumber GLOB '[0-9]*' "
+            "              THEN printf('%010d', CAST(issuenumber AS INTEGER)) "
+            "              ELSE issuenumber END",
+            (publicationcode,),
+        )
+        rows = cursor.fetchall()
+        cursor.close()
+        return [{
+            'id': row['issuecode'],
+            'issue_number': (row['issuenumber'] or '').strip(),
+            'title': (row['title'] or '').strip() or None,
+            'cover_date': row['oldestdate'],
+        } for row in rows]
+    except Exception as e:
+        app_logger.error(f"INDUCKS get_issues failed: {e}")
+        return []
+    finally:
+        conn.close()
+
+
+# =============================================================================
+# Issue Details
+# =============================================================================
+
+def _publisher(conn, issuecode: str) -> str:
+    """The publisher of an issue.
+
+    INDUCKS may attach several publishers to one issue, listed oldest first —
+    Topolino carries Mondadori, Disney Italia and Panini Comics. The most recent
+    one is the imprint that actually produced a modern issue, so the last row
+    wins.
+    """
+    cursor = conn.cursor()
+    cursor.execute(
+        "SELECT COALESCE(p.publishername, j.publisherid) AS name "
+        "FROM inducks_publishingjob j "
+        "LEFT JOIN inducks_publisher p ON p.publisherid = j.publisherid "
+        "WHERE j.issuecode = ?",
+        (issuecode,),
+    )
+    names = [row['name'] for row in cursor.fetchall() if row['name']]
+    cursor.close()
+    return names[-1] if names else ''
+
+
+def _issue_date(conn, issuecode: str, fallback: str) -> str:
+    """The publication date of an issue as 'YYYY-MM-DD', or '' if unknown.
+
+    ``inducks_issuedate`` carries the precise date where one is known and
+    ``inducks_issue.oldestdate`` is the fallback. Either may be the 9999
+    sentinel, which must become empty rather than a year 9999 that the date
+    check would read as a nine-thousand-year conflict.
+    """
+    cursor = conn.cursor()
+    cursor.execute(
+        "SELECT date FROM inducks_issuedate WHERE issuecode = ? ORDER BY date LIMIT 1",
+        (issuecode,),
+    )
+    row = cursor.fetchone()
+    cursor.close()
+    date = (row['date'] if row else '') or fallback or ''
+    return '' if date.startswith(_UNKNOWN_DATE_PREFIX) else date
+
+
+def _story_credits(conn, storyversioncode: str) -> Dict[str, List[str]]:
+    """Writer/penciller/inker names for one story version, in INDUCKS order."""
+    cursor = conn.cursor()
+    cursor.execute(
+        "SELECT j.plotwritartink AS job, COALESCE(p.fullname, j.personcode) AS name "
+        "FROM inducks_storyjob j "
+        "LEFT JOIN inducks_person p ON p.personcode = j.personcode "
+        "WHERE j.storyversioncode = ?",
+        (storyversioncode,),
+    )
+    rows = cursor.fetchall()
+    cursor.close()
+
+    credits: Dict[str, List[str]] = {'writers': [], 'pencillers': [], 'inkers': []}
+    for row in rows:
+        name, job = row['name'], row['job']
+        if not name:
+            continue
+        if job in _JOB_WRITER and name not in credits['writers']:
+            credits['writers'].append(name)
+        elif job in _JOB_PENCILLER and name not in credits['pencillers']:
+            credits['pencillers'].append(name)
+        elif job in _JOB_INKER and name not in credits['inkers']:
+            credits['inkers'].append(name)
+    return credits
+
+
+def _story_characters(conn, storyversioncode: str, language: str) -> List[str]:
+    """Character names for one story version, preferring the localised name.
+
+    A character may carry several names in one language, so the join is
+    restricted to the preferred one; without that restriction the row multiplies
+    and the same character appears two or three times over.
+    """
+    cursor = conn.cursor()
+    cursor.execute(
+        "SELECT COALESCE(NULLIF(cn.charactername, ''), c.charactername) AS name "
+        "FROM inducks_appearance a "
+        "LEFT JOIN inducks_character c ON c.charactercode = a.charactercode "
+        "LEFT JOIN inducks_charactername cn "
+        "       ON cn.charactercode = a.charactercode "
+        "      AND cn.languagecode = ? AND cn.preferred = 'Y' "
+        "WHERE a.storyversioncode = ?",
+        (language or 'en', storyversioncode),
+    )
+    rows = cursor.fetchall()
+    cursor.close()
+
+    seen: List[str] = []
+    for row in rows:
+        if row['name'] and row['name'] not in seen:
+            seen.append(row['name'])
+    return seen
+
+
+def _stories(conn, issuecode: str, language: str) -> List[Dict[str, Any]]:
+    """Everything printed inside an issue, in printed order."""
+    cursor = conn.cursor()
+    cursor.execute(
+        "SELECT e.position, e.title, e.storyversioncode, "
+        "       COALESCE(sv.kind, '') AS kind, COALESCE(s.title, '') AS storytitle "
+        "FROM inducks_entry e "
+        "LEFT JOIN inducks_storyversion sv ON sv.storyversioncode = e.storyversioncode "
+        "LEFT JOIN inducks_story s ON s.storycode = sv.storycode "
+        "WHERE e.issuecode = ? ORDER BY e.position",
+        (issuecode,),
+    )
+    rows = cursor.fetchall()
+    cursor.close()
+
+    stories = []
+    for row in rows:
+        story = {
+            'position': row['position'] or '',
+            'title': (row['title'] or row['storytitle'] or '').strip(),
+            'kind': row['kind'],
+            'writers': [],
+            'pencillers': [],
+            'inkers': [],
+            'characters': [],
+        }
+        code = row['storyversioncode']
+        if code:
+            story.update(_story_credits(conn, code))
+            story['characters'] = _story_characters(conn, code, language)
+        stories.append(story)
+    return stories
+
+
+def _merge(groups: List[List[str]]) -> Optional[str]:
+    """Flatten per-story credit lists into one comma-separated string.
+
+    Deduplicated, preserving first-appearance order, so the writer of the lead
+    story is named first.
+    """
+    seen: List[str] = []
+    for group in groups:
+        for value in group:
+            if value not in seen:
+                seen.append(value)
+    return ', '.join(seen) if seen else None
+
+
+def _summary(stories: List[Dict[str, Any]]) -> Optional[str]:
+    """The album's table of contents, one line per story.
+
+    ComicInfo has no representation for "one album, twelve unrelated stories",
+    so a mapping has to be chosen. This one keeps the album as the unit —
+    ``Series`` and ``Number`` name the album — and puts the contents in
+    ``Summary``, because that is what the file on disk actually is and what a
+    reader such as Komga displays.
+    """
+    lines = [s['title'] for s in stories if s['kind'] in STORY_KINDS and s['title']]
+    return '\n'.join(f'- {title}' for title in lines) if lines else None
+
+
+def get_issue_metadata(publicationcode: str, issue_number: str) -> Optional[Dict[str, Any]]:
+    """
+    Get ComicInfo-compatible metadata for one issue of an INDUCKS publication.
+
+    The lookup deliberately goes through ``publicationcode`` plus
+    ``issuenumber`` rather than composing an ``issuecode``: INDUCKS pads the
+    number inside the code to a variable width ("it/TL 3200" but "ae/DC    0"),
+    so composing it by hand is fragile.
+
+    Args:
+        publicationcode: INDUCKS publication code, e.g. "it/TL"
+        issue_number: Issue number as printed, e.g. "3200"
+
+    Returns:
+        Dict of ComicInfo fields, or None if the issue is not in the database
+    """
+    if not publicationcode or issue_number is None or str(issue_number).strip() == '':
+        return None
+
+    conn = get_connection()
+    if not conn:
+        return None
+
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT issuecode, publicationcode, issuenumber, title, pages, oldestdate "
+            "FROM inducks_issue WHERE publicationcode = ? AND issuenumber = ?",
+            (publicationcode, str(issue_number).strip()),
+        )
+        issue = cursor.fetchone()
+        cursor.close()
+
+        if not issue:
+            app_logger.debug(
+                f"INDUCKS get_issue_metadata: issue #{issue_number} not found in {publicationcode}"
+            )
+            return None
+
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT title, countrycode, languagecode FROM inducks_publication "
+            "WHERE publicationcode = ?",
+            (publicationcode,),
+        )
+        publication = cursor.fetchone() or {}
+        cursor.close()
+
+        language = (publication.get('languagecode') or '').strip()
+        issuecode = issue['issuecode']
+        stories = _stories(conn, issuecode, language)
+
+        return _build_comicinfo(
+            issuecode=issuecode,
+            series=series_name_for(conn, publication.get('title') or publicationcode),
+            number=(issue['issuenumber'] or str(issue_number)).strip(),
+            title=(issue['title'] or '').strip(),
+            publisher=_publisher(conn, issuecode),
+            pages=issue['pages'],
+            language=language,
+            date=_issue_date(conn, issuecode, issue['oldestdate'] or ''),
+            stories=stories,
+        )
+    except sqlite3.Error as db_error:
+        app_logger.error(f"Database error in INDUCKS get_issue_metadata: {db_error}")
+        return None
+    except Exception as e:
+        app_logger.error(f"Exception in INDUCKS get_issue_metadata: {e}")
+        return None
+    finally:
+        conn.close()
+
+
+def issue_url(issuecode: str) -> str:
+    """The inducks.org page for an issue, for ComicInfo's Web field."""
+    return f"https://inducks.org/issue.php?c={str(issuecode).replace(' ', '+')}"
+
+
+def _build_comicinfo(*, issuecode: str, series: str, number: str, title: str,
+                     publisher: str, pages: Any, language: str, date: str,
+                     stories: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Flatten one anthology issue into the ComicInfo fields CLU writes.
+
+    Credits and characters are merged across the stories rather than reported
+    per story, because ComicInfo has one Writer field and not twelve. Covers and
+    illustrations are excluded from the merge — a cover artist is not the
+    penciller of the book — but the issue keeps them in the database.
+
+    Every key here survives ``core.comicinfo.generate_comicinfo_xml``'s
+    allowlist; a key added that is not in that allowlist would be computed and
+    silently dropped.
+    """
+    told = [s for s in stories if s['kind'] in STORY_KINDS]
+    retrieved = datetime.now().strftime('%Y-%m-%d')
+
+    metadata = {
+        'Series': series or None,
+        'Number': number or None,
+        'Title': title or None,
+        'Summary': _summary(stories),
+        'Publisher': publisher or None,
+        'Year': int(date[:4]) if len(date) >= 4 and date[:4].isdigit() else None,
+        'Month': int(date[5:7]) if len(date) >= 7 and date[5:7].isdigit() else None,
+        'Day': int(date[8:10]) if len(date) >= 10 and date[8:10].isdigit() else None,
+        'PageCount': pages or None,
+        'LanguageISO': language or None,
+        'Writer': _merge([s['writers'] for s in told]),
+        'Penciller': _merge([s['pencillers'] for s in told]),
+        'Inker': _merge([s['inkers'] for s in told]),
+        'Characters': _merge([s['characters'] for s in told]),
+        'Web': issue_url(issuecode),
+        # Notes has to start with a recognisable source string: #524 centralised
+        # the "already tagged, skip this file" check on it.
+        'Notes': f'Metadata from INDUCKS. Issue: {issuecode} — retrieved {retrieved}.',
+    }
+
+    return {k: v for k, v in metadata.items() if v is not None}

--- a/models/inducks.py
+++ b/models/inducks.py
@@ -21,6 +21,7 @@ country filter is therefore ambiguous by construction, which is what
 ``get_configured_countries`` exists to prevent.
 """
 import os
+import re
 import sqlite3
 import unicodedata
 from datetime import datetime
@@ -57,6 +58,43 @@ _JOB_INKER = ('i',)
 # opposed to covers ("c"), illustrations ("i") and other filler. Only these
 # contribute to the table of contents and the merged credits.
 STORY_KINDS = frozenset({'n', 't'})
+
+# Italian series distinguish their runs with an ordinal, and a filename and
+# INDUCKS rarely spell it the same way: a folder says "II Serie" or "2a serie"
+# where INDUCKS writes "(Seconda Serie)". Only applied to the token immediately
+# before "serie", so an issue titled "II" is untouched.
+_SERIES_ORDINALS = {
+    'i': 'prima', '1': 'prima', '1a': 'prima', 'prima': 'prima',
+    'ii': 'seconda', '2': 'seconda', '2a': 'seconda', 'seconda': 'seconda',
+    'iii': 'terza', '3': 'terza', '3a': 'terza', 'terza': 'terza',
+    'iv': 'quarta', '4': 'quarta', '4a': 'quarta', 'quarta': 'quarta',
+}
+
+# Words carrying no identity in an Italian Disney title, dropped only by the
+# last-resort token match. "walt" is here because INDUCKS and the scene
+# disagree about it constantly -- "Le grandi storie di Walt Disney" against
+# INDUCKS' "Le grandi storie Disney", and the reverse in the next folder along.
+# "disney" itself is deliberately NOT here: it is the one word that still
+# separates these titles from everything else in a library.
+_TOKEN_STOPWORDS = frozenset({
+    'di', 'del', 'della', 'dei', 'delle', 'degli', 'de', 'd',
+    'la', 'il', 'lo', 'i', 'gli', 'le', 'l', 'e', 'a', 'walt',
+})
+
+# A trailing marker naming a slice of a run rather than the run itself:
+# "Topolino anno 1975", "Anno 1986 vol 1571-1622", "Albo d'oro v2", the
+# "Repack" a scene release adds. Folders are filed this way far more often than
+# they are named after the publication, and the tail is pure noise for matching.
+_RUN_MARKER_TAIL = re.compile(
+    r"[\s_\-]*(?:"
+    r"\b(?:anno|annata)\b[\s_\-]*\d{4}(?:[\s_\-]*\d{4})?"
+    r"|\bv(?:ol(?:ume)?)?[.\s_\-]*\d{1,3}\b"
+    r"|\b(?:numeri|num|vol|volumi|voilumi|n)\b[\s_\-]*\d{1,5}\s*-\s*\d{1,5}"
+    r"|\b\d{1,5}\s*-\s*\d{1,5}\b"
+    r"|\brepack\b"
+    r")\s*$",
+    re.I,
+)
 
 # INDUCKS writes this in a date column to mean "unknown" rather than leaving it
 # empty, so it has to be filtered explicitly everywhere a date is read. It is
@@ -353,13 +391,50 @@ def series_name_for(conn, title: str, colliding: Optional[Set[str]] = None) -> s
     return title if normalize_title(stripped) in colliding else stripped
 
 
+def normalise_ordinals(key: str) -> str:
+    """Rewrite an ordinal naming a series run into the word INDUCKS uses.
+
+    "i grandi classici disney ii serie" becomes "... seconda serie", which is
+    what INDUCKS calls it. Only the token immediately before "serie" is
+    rewritten, so a title that merely contains a numeral is left alone.
+    """
+    tokens = key.split()
+    out = []
+    for index, token in enumerate(tokens):
+        following = tokens[index + 1] if index + 1 < len(tokens) else ''
+        out.append(_SERIES_ORDINALS[token]
+                   if token in _SERIES_ORDINALS and following == 'serie'
+                   else token)
+    return ' '.join(out)
+
+
+def significant_tokens(key: str) -> frozenset:
+    """The words of a normalised title that actually identify it."""
+    return frozenset(token for token in key.split() if token not in _TOKEN_STOPWORDS)
+
+
+def strip_run_marker(name: str) -> str:
+    """Drop a trailing marker naming a slice of a run rather than the run.
+
+    Folders in a Disney library are filed by year far more often than by
+    publication — "Topolino anno 1975", "Anno 1986 vol 1571-1622" — and the
+    tail is noise for matching. Applied repeatedly, since the markers stack.
+    """
+    previous = None
+    while previous != name:
+        previous = name
+        name = _RUN_MARKER_TAIL.sub('', name).strip(' _-')
+    return name
+
+
 def _search_keys(series_name: str) -> List[str]:
     """Lookup keys for a series name, most specific first."""
     keys: List[str] = []
     for variant in (series_name, strip_qualifier(series_name)):
         key = normalize_title(variant)
-        if key and key not in keys:
-            keys.append(key)
+        for candidate in (key, normalise_ordinals(key)):
+            if candidate and candidate not in keys:
+                keys.append(candidate)
     return keys
 
 
@@ -446,22 +521,59 @@ def search_series(series_name: str, year: Optional[int] = None,
     try:
         exact: Dict[str, List[Dict[str, Any]]] = {}
         stripped: Dict[str, List[Dict[str, Any]]] = {}
+        by_tokens: Dict[frozenset, List[Dict[str, Any]]] = {}
 
         for row in _publication_rows(conn, country_codes):
             title = row['title']
             for index, variant in ((exact, title), (stripped, strip_qualifier(title))):
-                key = normalize_title(variant)
-                if key:
-                    index.setdefault(key, []).append(row)
+                for key in {normalize_title(variant),
+                            normalise_ordinals(normalize_title(variant))}:
+                    if key:
+                        index.setdefault(key, []).append(row)
+            for variant in (title, strip_qualifier(title)):
+                tokens = significant_tokens(normalize_title(variant))
+                if tokens:
+                    by_tokens.setdefault(tokens, []).append(row)
 
+        # Keys run from the most specific form of the name to the least, and
+        # the first that matches anything wins outright — a file that spells
+        # out "Topolino (giornale)" must never be answered by the publication
+        # merely called "Topolino".
+        #
+        # Within one key, though, both indexes are consulted. A run that
+        # continues into a "(seconda serie)" is indexed under the same stripped
+        # title as the first series, so taking only the exact match hides the
+        # publication that actually holds the later issues. Which of the two is
+        # right is settled afterwards by ``narrow_to_issue``, on evidence,
+        # rather than by which index answered first.
         matches: List[Dict[str, Any]] = []
+        exact_titles: Set[str] = set()
+        seen: Set[str] = set()
         for key in _search_keys(series_name):
-            for index in (exact, stripped):
-                if index.get(key):
-                    matches = index[key]
-                    break
+            for index, is_exact in ((exact, True), (stripped, False)):
+                for row in index.get(key, []):
+                    code = row['publicationcode']
+                    if is_exact:
+                        exact_titles.add(code)
+                    if code not in seen:
+                        seen.add(code)
+                        matches.append(row)
             if matches:
                 break
+
+        # Last resort: the same significant words in any arrangement, ignoring
+        # Italian articles and prepositions. This is what reaches "Le grandi
+        # storie di Walt Disney - L'opera omnia di Romano Scarpa" from INDUCKS'
+        # "Le grandi storie Disney - ...". Requires the whole token set to
+        # match, not a subset, and at least two tokens, so it stays a spelling
+        # difference rather than a fuzzy search.
+        if not matches:
+            tokens = significant_tokens(normalize_title(series_name))
+            if len(tokens) >= 2:
+                for row in by_tokens.get(tokens, []):
+                    if row['publicationcode'] not in seen:
+                        seen.add(row['publicationcode'])
+                        matches.append(row)
 
         if not matches:
             return []
@@ -478,6 +590,7 @@ def search_series(series_name: str, year: Optional[int] = None,
                 'issue_count': derived['issue_count'],
                 'country_code': row['countrycode'] or '',
                 'language_code': row['languagecode'] or '',
+                'exact_title': row['publicationcode'] in exact_titles,
             })
 
         # Closest start year first when the caller supplied one, so a name that
@@ -497,6 +610,110 @@ def search_series(series_name: str, year: Optional[int] = None,
         return []
     finally:
         conn.close()
+
+
+def issue_dates(publicationcode: str, issue_numbers: List[str],
+                conn=None) -> Dict[str, Optional[str]]:
+    """The publication date of each of these issue numbers, where it has one.
+
+    Leading zeros are stripped on both sides, since INDUCKS stores an
+    unpadded number and CLU parses a padded one. A number absent from the
+    result is absent from the publication.
+    """
+    wanted = {(str(n or '').strip().lstrip('0') or '0') for n in issue_numbers if str(n or '').strip()}
+    if not publicationcode or not wanted:
+        return {}
+
+    own_conn = conn is None
+    if own_conn:
+        conn = get_connection()
+    if not conn:
+        return {}
+    try:
+        cursor = conn.cursor()
+        # Matched in SQL on the number as stored and as zero-padded to the four
+        # widths INDUCKS and CLU between them produce, rather than by scanning
+        # the publication: Topolino alone has 3,775 issues, and this runs once
+        # per candidate per file.
+        placeholders = ','.join('?' for _ in range(len(wanted) * 5))
+        variants = [v for n in wanted
+                    for v in (n, n.zfill(2), n.zfill(3), n.zfill(4), n.zfill(5))]
+        cursor.execute(
+            "SELECT issuenumber, "
+            "       NULLIF(NULLIF(oldestdate, ''), '9999-12-31') AS oldestdate "
+            f"FROM inducks_issue WHERE publicationcode = ? AND issuenumber IN ({placeholders})",
+            (publicationcode, *variants),
+        )
+        found = {}
+        for row in cursor.fetchall():
+            key = (row['issuenumber'] or '').strip().lstrip('0') or '0'
+            if key in wanted and key not in found:
+                found[key] = row['oldestdate']
+        cursor.close()
+        return found
+    except Exception as e:
+        app_logger.error(f"INDUCKS issue_dates failed: {e}")
+        return {}
+    finally:
+        if own_conn:
+            conn.close()
+
+
+def narrow_to_issue(candidates: List[Dict[str, Any]], issue_number: str,
+                    year: Optional[int] = None,
+                    tolerance: int = 2) -> List[Dict[str, Any]]:
+    """Reduce candidate publications to those that can hold this issue.
+
+    A Disney title names several runs, and the title alone cannot say which.
+    The issue number can: of the eleven Italian publications whose name reduces
+    to "Topolino", only ``it/TL`` has an issue 1500 at all. This is evidence
+    the caller already has, not a heuristic — and it can only remove candidates,
+    never introduce one the name did not produce.
+
+    Applied in order, each step only when more than one candidate survives the
+    last:
+
+    1. the publication actually contains that issue number;
+    2. that issue's own date is within ``tolerance`` of the year the filename
+       claims, where the filename claims one;
+    3. the title matched exactly rather than with its qualifier stripped.
+
+    Returns every survivor. Two candidates that all three tests cannot separate
+    are genuinely ambiguous and the caller should decline rather than pick.
+    """
+    raw = str(issue_number or '').strip()
+    if not candidates or not raw:
+        return list(candidates)
+    # "000" is issue 0, not the absence of one, so the default only applies
+    # after we know a number was supplied at all.
+    number = raw.lstrip('0') or '0'
+
+    conn = get_connection()
+    if not conn:
+        return list(candidates)
+    try:
+        dates = {c['id']: issue_dates(c['id'], [number], conn=conn).get(number, ...)
+                 for c in candidates}
+    finally:
+        conn.close()
+
+    holding = [c for c in candidates if dates.get(c['id']) is not ...]
+    if len(holding) <= 1:
+        return holding
+
+    if year:
+        dated = []
+        for candidate in holding:
+            date = dates.get(candidate['id']) or ''
+            if len(date) >= 4 and date[:4].isdigit() and abs(int(date[:4]) - year) <= tolerance:
+                dated.append(candidate)
+        if dated:
+            holding = dated
+    if len(holding) <= 1:
+        return holding
+
+    titled = [c for c in holding if c.get('exact_title')]
+    return titled if len(titled) == 1 else holding
 
 
 def get_series(publicationcode: str) -> Optional[Dict[str, Any]]:

--- a/models/inducks.py
+++ b/models/inducks.py
@@ -105,6 +105,10 @@ _UNKNOWN_DATE_PREFIX = '9999'
 # Cached set of INDUCKS tables actually present in the connected database.
 _AVAILABLE_TABLES_CACHE: Optional[Set[str]] = None
 
+# Cached result of ``_colliding_stripped_titles``, invalidated alongside the
+# table cache above. See that function for why this needs caching at all.
+_COLLIDING_TITLES_CACHE: Optional[Set[str]] = None
+
 
 # =============================================================================
 # Helper Functions
@@ -140,6 +144,44 @@ def strip_qualifier(title: str) -> str:
 def _dict_factory(cursor, row):
     """Row factory returning plain dicts, matching models.gcd."""
     return {col[0]: row[idx] for idx, col in enumerate(cursor.description)}
+
+
+def _normalize_issue_number(issue_number: Any) -> str:
+    """Canonical, comparable form of an issue number.
+
+    INDUCKS pads issue numbers to whatever width the source data used for a
+    given publication ("0007" in one, "3200" unpadded in another), and a
+    filename or caller may supply either form. Every function that matches on
+    issue number -- ``issue_dates``, ``narrow_to_issue`` and
+    ``get_issue_metadata`` -- keys off this single unpadded form, so that
+    whatever ``narrow_to_issue`` accepts for a candidate, ``get_issue_metadata``
+    can also fetch. Before this was shared, the two used different rules and a
+    publication narrowed to on the padded form could return None when fetched
+    on the unpadded one (or vice versa).
+
+    "000" is issue 0, not the absence of a number, so this only ever strips
+    *leading* zeros and never returns an empty string for real input.
+    """
+    return str(issue_number or '').strip().lstrip('0') or '0'
+
+
+def _issue_number_query_variants(issue_number: Any) -> List[str]:
+    """Every ``inducks_issue.issuenumber`` spelling this number could take.
+
+    Built from the normalized form: the unpadded number itself, plus every
+    width from 2 to 5 digits INDUCKS is seen padding to. Used to build a SQL
+    ``IN (...)`` clause so a lookup does not have to guess which width the
+    stored row uses.
+    """
+    number = _normalize_issue_number(issue_number)
+    if not number:
+        return []
+    variants = [number]
+    for width in (2, 3, 4, 5):
+        padded = number.zfill(width)
+        if padded not in variants:
+            variants.append(padded)
+    return variants
 
 
 # =============================================================================
@@ -270,9 +312,15 @@ def get_available_inducks_tables(conn=None, *, force_refresh: bool = False) -> S
 
 
 def invalidate_inducks_table_cache() -> None:
-    """Drop the cached table set, after the configured path changes."""
-    global _AVAILABLE_TABLES_CACHE
+    """Drop the cached table set and the colliding-titles cache.
+
+    Both are only valid for the connected database, so both must go together
+    whenever the configured path changes -- a stale colliding-titles set would
+    keep answering for the previous build's publications.
+    """
+    global _AVAILABLE_TABLES_CACHE, _COLLIDING_TITLES_CACHE
     _AVAILABLE_TABLES_CACHE = None
+    _COLLIDING_TITLES_CACHE = None
 
 
 # =============================================================================
@@ -360,7 +408,20 @@ def _colliding_stripped_titles(conn) -> Set[str]:
     is what tells "Topolino (libretto)" from "Topolino (giornale)", and dropping
     it from the series name would make a reader merge two unrelated runs into
     one shelf entry.
+
+    Cached at module scope rather than recomputed per call. This set does not
+    change during a run, but ``get_issue_metadata`` calls
+    ``series_name_for`` -- and through it, this function -- once per file with
+    no ``colliding`` argument, unlike ``search_series`` which computes it once
+    and threads it through. Without the cache, a 3,018-file batch reruns this
+    scan (7,310 rows on the real build, each put through ``normalize_title``'s
+    NFKD decomposition) once per file for no reason. Invalidated alongside
+    ``_AVAILABLE_TABLES_CACHE`` in ``invalidate_inducks_table_cache``.
     """
+    global _COLLIDING_TITLES_CACHE
+    if _COLLIDING_TITLES_CACHE is not None:
+        return _COLLIDING_TITLES_CACHE
+
     counts: Dict[str, int] = {}
     cursor = conn.cursor()
     cursor.execute("SELECT title FROM inducks_publication WHERE title IS NOT NULL AND title <> ''")
@@ -369,7 +430,10 @@ def _colliding_stripped_titles(conn) -> Set[str]:
         if key:
             counts[key] = counts.get(key, 0) + 1
     cursor.close()
-    return {key for key, count in counts.items() if count > 1}
+
+    result = {key for key, count in counts.items() if count > 1}
+    _COLLIDING_TITLES_CACHE = result
+    return result
 
 
 def series_name_for(conn, title: str, colliding: Optional[Set[str]] = None) -> str:
@@ -616,11 +680,14 @@ def issue_dates(publicationcode: str, issue_numbers: List[str],
                 conn=None) -> Dict[str, Optional[str]]:
     """The publication date of each of these issue numbers, where it has one.
 
-    Leading zeros are stripped on both sides, since INDUCKS stores an
-    unpadded number and CLU parses a padded one. A number absent from the
-    result is absent from the publication.
+    Leading zeros are stripped on both sides, since INDUCKS pads issue numbers
+    to different widths depending on the publication and CLU's caller may
+    supply either a padded or an unpadded form. A number absent from the
+    result is absent from the publication. See ``_normalize_issue_number``,
+    which this and ``get_issue_metadata`` both key off, so a number this
+    accepts is also one ``get_issue_metadata`` can fetch.
     """
-    wanted = {(str(n or '').strip().lstrip('0') or '0') for n in issue_numbers if str(n or '').strip()}
+    wanted = {_normalize_issue_number(n) for n in issue_numbers if str(n or '').strip()}
     if not publicationcode or not wanted:
         return {}
 
@@ -631,13 +698,12 @@ def issue_dates(publicationcode: str, issue_numbers: List[str],
         return {}
     try:
         cursor = conn.cursor()
-        # Matched in SQL on the number as stored and as zero-padded to the four
+        # Matched in SQL on the number as stored and as zero-padded to the
         # widths INDUCKS and CLU between them produce, rather than by scanning
         # the publication: Topolino alone has 3,775 issues, and this runs once
         # per candidate per file.
-        placeholders = ','.join('?' for _ in range(len(wanted) * 5))
-        variants = [v for n in wanted
-                    for v in (n, n.zfill(2), n.zfill(3), n.zfill(4), n.zfill(5))]
+        variants = [v for n in wanted for v in _issue_number_query_variants(n)]
+        placeholders = ','.join('?' for _ in variants)
         cursor.execute(
             "SELECT issuenumber, "
             "       NULLIF(NULLIF(oldestdate, ''), '9999-12-31') AS oldestdate "
@@ -646,7 +712,7 @@ def issue_dates(publicationcode: str, issue_numbers: List[str],
         )
         found = {}
         for row in cursor.fetchall():
-            key = (row['issuenumber'] or '').strip().lstrip('0') or '0'
+            key = _normalize_issue_number(row['issuenumber'])
             if key in wanted and key not in found:
                 found[key] = row['oldestdate']
         cursor.close()
@@ -684,9 +750,7 @@ def narrow_to_issue(candidates: List[Dict[str, Any]], issue_number: str,
     raw = str(issue_number or '').strip()
     if not candidates or not raw:
         return list(candidates)
-    # "000" is issue 0, not the absence of one, so the default only applies
-    # after we know a number was supplied at all.
-    number = raw.lstrip('0') or '0'
+    number = _normalize_issue_number(raw)
 
     conn = get_connection()
     if not conn:
@@ -798,13 +862,19 @@ def _publisher(conn, issuecode: str) -> str:
     Topolino carries Mondadori, Disney Italia and Panini Comics. The most recent
     one is the imprint that actually produced a modern issue, so the last row
     wins.
+
+    Explicit ``ORDER BY j.rowid``: row order for an unordered scan is not part
+    of SQLite's contract, only insertion order into ``inducks_publishingjob``
+    is -- and rowid is the one thing that tracks it regardless of which index,
+    if any, the planner chooses to satisfy the WHERE clause.
     """
     cursor = conn.cursor()
     cursor.execute(
         "SELECT COALESCE(p.publishername, j.publisherid) AS name "
         "FROM inducks_publishingjob j "
         "LEFT JOIN inducks_publisher p ON p.publisherid = j.publisherid "
-        "WHERE j.issuecode = ?",
+        "WHERE j.issuecode = ? "
+        "ORDER BY j.rowid",
         (issuecode,),
     )
     names = [row['name'] for row in cursor.fetchall() if row['name']]
@@ -972,10 +1042,16 @@ def get_issue_metadata(publicationcode: str, issue_number: str) -> Optional[Dict
 
     try:
         cursor = conn.cursor()
+        # Matched against every zero-padding width, not just the literal
+        # string given: whatever narrow_to_issue accepted for this candidate
+        # (padded or not) must also be fetchable here. See
+        # _issue_number_query_variants and the module note on issue_dates.
+        variants = _issue_number_query_variants(issue_number)
+        placeholders = ','.join('?' for _ in variants)
         cursor.execute(
             "SELECT issuecode, publicationcode, issuenumber, title, pages, oldestdate "
-            "FROM inducks_issue WHERE publicationcode = ? AND issuenumber = ?",
-            (publicationcode, str(issue_number).strip()),
+            f"FROM inducks_issue WHERE publicationcode = ? AND issuenumber IN ({placeholders})",
+            (publicationcode, *variants),
         )
         issue = cursor.fetchone()
         cursor.close()

--- a/models/providers/__init__.py
+++ b/models/providers/__init__.py
@@ -217,6 +217,7 @@ from .comicvine_provider import ComicVineProvider
 from .comicvine_sqlite_provider import ComicVineSqliteProvider
 from .gcd_provider import GCDProvider
 from .gcd_api_provider import GCDApiProvider
+from .inducks_provider import InducksProvider
 from .anilist_provider import AniListProvider
 from .bedetheque_provider import BedethequeProvider
 from .mangadex_provider import MangaDexProvider
@@ -247,6 +248,7 @@ __all__ = [
     'ComicVineSqliteProvider',
     'GCDProvider',
     'GCDApiProvider',
+    'InducksProvider',
     'AniListProvider',
     'BedethequeProvider',
     'MangaDexProvider',

--- a/models/providers/base.py
+++ b/models/providers/base.py
@@ -29,6 +29,7 @@ class ProviderType(Enum):
     COMICVINE_SQLITE = "comicvine_sqlite"
     GCD = "gcd"
     GCD_API = "gcd_api"
+    INDUCKS = "inducks"
     ANILIST = "anilist"
     BEDETHEQUE = "bedetheque"
     MANGADEX = "mangadex"

--- a/models/providers/inducks_provider.py
+++ b/models/providers/inducks_provider.py
@@ -1,0 +1,222 @@
+"""
+INDUCKS Provider Adapter.
+
+Wraps the INDUCKS SQLite implementation (a user-provided database file built
+from the dumps at https://inducks.org/) to conform to the BaseProvider
+interface. INDUCKS is the reference index of Disney comics worldwide, which no
+other provider covers usefully: a Disney issue is an anthology of a dozen
+unrelated stories, and the general-purpose databases model it as one book.
+"""
+from typing import Optional, List, Dict, Any
+
+from core.app_logging import app_logger
+from .base import BaseProvider, ProviderType, ProviderCredentials, SearchResult, IssueResult
+from . import register_provider
+
+
+@register_provider
+class InducksProvider(BaseProvider):
+    """INDUCKS metadata provider using a local SQLite database file."""
+
+    provider_type = ProviderType.INDUCKS
+    display_name = "INDUCKS (Disney)"
+    requires_auth = True
+    auth_fields = ["database_path"]
+    rate_limit = 1000  # Local database, high rate limit
+
+    def __init__(self, credentials: Optional[ProviderCredentials] = None):
+        super().__init__(credentials)
+
+    def _is_configured(self) -> bool:
+        """Check if the INDUCKS SQLite database is configured and present."""
+        from models import inducks as inducks_module
+        status = inducks_module.check_database_status()
+        return status.get('inducks_available', False)
+
+    def test_connection(self) -> bool:
+        """Test the INDUCKS SQLite database — open it and verify the core tables."""
+        try:
+            if not self._is_configured():
+                return False
+
+            from models import inducks as inducks_module
+            conn = inducks_module.get_connection()
+            if not conn:
+                return False
+            try:
+                available = inducks_module.get_available_inducks_tables(conn=conn)
+                return inducks_module.INDUCKS_CORE_TABLES.issubset(available)
+            finally:
+                conn.close()
+        except Exception as e:
+            app_logger.error(f"INDUCKS connection test failed: {e}")
+            return False
+
+    def search_series(self, query: str, year: Optional[int] = None) -> List[SearchResult]:
+        """Search for publications in the INDUCKS database.
+
+        Returns every publication the name resolves to, not a single best guess.
+        A Disney title routinely names several runs, and ``_resolve_series_auto``
+        is built to send an ambiguous name to review rather than pick one.
+        """
+        try:
+            if not self._is_configured():
+                return []
+
+            from models import inducks as inducks_module
+            return [SearchResult(
+                provider=self.provider_type,
+                id=result['id'],
+                title=result['name'],
+                year=result.get('year_began'),
+                publisher=None,  # INDUCKS records the publisher per issue, not per publication
+                issue_count=result.get('issue_count'),
+                cover_url=None,  # INDUCKS does not distribute cover images
+                description=None,
+                alternate_title=result.get('title') if result.get('title') != result['name'] else None,
+            ) for result in inducks_module.search_series(query, year)]
+        except Exception as e:
+            app_logger.error(f"INDUCKS search_series failed: {e}")
+            return []
+
+    def get_series(self, series_id: str) -> Optional[SearchResult]:
+        """Get publication details by INDUCKS publication code, e.g. 'it/TL'."""
+        try:
+            if not self._is_configured():
+                return None
+
+            from models import inducks as inducks_module
+            result = inducks_module.get_series(series_id)
+            if not result:
+                return None
+
+            return SearchResult(
+                provider=self.provider_type,
+                id=result['id'],
+                title=result['name'],
+                year=result.get('year_began'),
+                publisher=None,
+                issue_count=result.get('issue_count'),
+                cover_url=None,
+                description=None,
+                alternate_title=result.get('title') if result.get('title') != result['name'] else None,
+            )
+        except Exception as e:
+            app_logger.error(f"INDUCKS get_series failed: {e}")
+            return None
+
+    def get_issues(self, series_id: str) -> List[IssueResult]:
+        """Get all issues for an INDUCKS publication."""
+        try:
+            if not self._is_configured():
+                return []
+
+            from models import inducks as inducks_module
+            return [IssueResult(
+                provider=self.provider_type,
+                id=issue['id'],
+                series_id=series_id,
+                issue_number=issue['issue_number'],
+                title=issue.get('title'),
+                cover_date=issue.get('cover_date'),
+                store_date=None,
+                cover_url=None,
+                summary=None,
+            ) for issue in inducks_module.get_issues(series_id)]
+        except Exception as e:
+            app_logger.error(f"INDUCKS get_issues failed: {e}")
+            return []
+
+    def get_issue(self, issue_id: str) -> Optional[IssueResult]:
+        """Get issue details by INDUCKS issue code, e.g. 'it/TL 3200'.
+
+        The issue code embeds its publication code, so the publication is read
+        back off the row rather than asked for.
+        """
+        try:
+            if not self._is_configured():
+                return None
+
+            from models import inducks as inducks_module
+            conn = inducks_module.get_connection()
+            if not conn:
+                return None
+
+            try:
+                cursor = conn.cursor()
+                cursor.execute(
+                    "SELECT issuecode, publicationcode, issuenumber, title, "
+                    "       NULLIF(NULLIF(oldestdate, ''), '9999-12-31') AS oldestdate "
+                    "FROM inducks_issue WHERE issuecode = ?",
+                    (issue_id,),
+                )
+                row = cursor.fetchone()
+                cursor.close()
+
+                if not row:
+                    return None
+
+                return IssueResult(
+                    provider=self.provider_type,
+                    id=row['issuecode'],
+                    series_id=row['publicationcode'],
+                    issue_number=(row['issuenumber'] or '').strip(),
+                    title=(row['title'] or '').strip() or None,
+                    cover_date=row['oldestdate'],
+                    store_date=None,
+                    cover_url=None,
+                    summary=None,
+                )
+            finally:
+                conn.close()
+        except Exception as e:
+            app_logger.error(f"INDUCKS get_issue failed: {e}")
+            return None
+
+    def get_issue_metadata(self, series_id: str, issue_number: str) -> Optional[Dict[str, Any]]:
+        """
+        Get full issue metadata for one issue of a publication.
+
+        Declared here rather than inherited: ``BaseProvider`` does not require
+        it, but every batch-path lookup calls it.
+        """
+        try:
+            if not self._is_configured():
+                return None
+
+            from models import inducks as inducks_module
+            return inducks_module.get_issue_metadata(series_id, issue_number)
+        except Exception as e:
+            app_logger.error(f"INDUCKS get_issue_metadata failed: {e}")
+            return None
+
+    def to_comicinfo(self, issue: IssueResult, series: Optional[SearchResult] = None) -> Dict[str, Any]:
+        """Convert INDUCKS issue data to ComicInfo.xml fields."""
+        try:
+            if issue.series_id and issue.issue_number:
+                from models import inducks as inducks_module
+                metadata = inducks_module.get_issue_metadata(issue.series_id, issue.issue_number)
+                if metadata:
+                    # Already a ComicInfo-compatible dict.
+                    return metadata
+
+            # Fallback: build from IssueResult alone. Reached only when the
+            # issue has since gone from the database, so it carries no stories,
+            # no credits and no characters.
+            comicinfo = {
+                'Series': series.title if series else None,
+                'Number': issue.issue_number,
+                'Title': issue.title,
+                'Notes': f'Metadata from INDUCKS. Issue: {issue.id}',
+            }
+
+            if issue.cover_date and len(issue.cover_date) >= 4:
+                try:
+                    comicinfo['Year'] = int(issue.cover_date[:4])
+                except ValueError:
+                    pass
+
+            return {k: v for k, v in comicinfo.items() if v is not None}
+        except Exception as e:
+            app_logger.error(f"INDUCKS to_comicinfo failed: {e}")
+            return {}

--- a/routes/metadata.py
+++ b/routes/metadata.py
@@ -27,7 +27,7 @@ from core.app_logging import app_logger
 from core.config import config
 from core.auth import require_role
 from helpers.library import is_valid_library_path
-from models import gcd, metron, comicvine, comicvine_sqlite
+from models import gcd, inducks, metron, comicvine, comicvine_sqlite
 from models.gcd import STOPWORDS
 
 metadata_bp = Blueprint('metadata', __name__)
@@ -1080,6 +1080,7 @@ def batch_metadata():
             comicvine_sqlite_available = 'comicvine_sqlite' in enabled_providers
             metron_available = 'metron' in enabled_providers
             gcd_available = 'gcd' in enabled_providers
+            inducks_available = 'inducks' in enabled_providers
             anilist_available = 'anilist' in enabled_providers
             bedetheque_available = 'bedetheque' in enabled_providers
             mangadex_available = 'mangadex' in enabled_providers
@@ -1091,12 +1092,13 @@ def batch_metadata():
             comicvine_sqlite_available = comicvine_sqlite.check_database_status().get('cv_sqlite_available', False)
             metron_available = metron.is_metron_configured()
             gcd_available = gcd.check_database_status().get('gcd_available', False)
+            inducks_available = inducks.check_database_status().get('inducks_available', False)
             anilist_available = False
             bedetheque_available = False
             mangadex_available = False
             mangaupdates_available = False
 
-        app_logger.info(f"Batch metadata: CV={comicvine_available}, Metron={metron_available}, GCD={gcd_available}, AniList={anilist_available}, MangaDex={mangadex_available}, MU={mangaupdates_available}")
+        app_logger.info(f"Batch metadata: CV={comicvine_available}, Metron={metron_available}, GCD={gcd_available}, INDUCKS={inducks_available}, AniList={anilist_available}, MangaDex={mangadex_available}, MU={mangaupdates_available}")
 
         # Resolved provider order (used by the frontend skip button to know what
         # comes after the current provider). Library order when available,
@@ -1110,6 +1112,7 @@ def batch_metadata():
                 ('comicvine', comicvine_available),
                 ('gcd', gcd_available),
                 ('gcd_api', True),  # gcd_api has no availability flag; gated per-file
+                ('inducks', inducks_available),
             ) if avail]
 
         # Honor user-skipped providers: drop them from availability so neither
@@ -1124,6 +1127,8 @@ def batch_metadata():
                 comicvine_sqlite_available = False
             if 'gcd' in skip_providers:
                 gcd_available = False
+            if 'inducks' in skip_providers:
+                inducks_available = False
             if 'anilist' in skip_providers:
                 anilist_available = False
             if 'mangadex' in skip_providers:
@@ -1758,6 +1763,58 @@ def batch_metadata():
                             app_logger.warning(f"GCD API lookup failed for {filename}: {e}")
                         return False
 
+                    # Helper function for INDUCKS lookup (Disney material)
+                    def try_inducks():
+                        nonlocal metadata, source
+                        if not inducks_available:
+                            return False
+                        try:
+                            inducks_series_name = os.path.basename(directory)
+                            # A four-digit year is noise, but a parenthetical
+                            # qualifier is not: INDUCKS uses exactly that form to
+                            # tell publications apart, and "Topolino (giornale)"
+                            # is a different publication from "Topolino".
+                            inducks_series_name = re.sub(r'\s*\(\d{4}\).*$', '', inducks_series_name)
+                            inducks_series_name = re.sub(r'\s*v\d+.*$', '', inducks_series_name).strip()
+                            if not inducks_series_name:
+                                return False
+
+                            candidates = inducks.search_series(inducks_series_name, gcd_year)
+                            if not candidates:
+                                return False
+
+                            if len(candidates) > 1 and gcd_year:
+                                # A folder year is evidence, not a tiebreak: two
+                                # runs published under the identical title are
+                                # told apart by when they started, which is
+                                # exactly the test core.bulk_metadata applies.
+                                dated = [c for c in candidates if c.get('year_began') == gcd_year]
+                                if len(dated) == 1:
+                                    candidates = dated
+
+                            # Refuse to guess. The same Disney title names
+                            # several runs, and picking one arbitrarily is how a
+                            # library ends up confidently mislabelled -- the
+                            # review queue is the right answer here.
+                            if len(candidates) > 1:
+                                app_logger.info(
+                                    f"INDUCKS: '{inducks_series_name}' matches "
+                                    f"{len(candidates)} publications, skipping batch auto-select"
+                                )
+                                return False
+
+                            publication = candidates[0]
+                            metadata = inducks.get_issue_metadata(publication['id'], issue_number)
+                            if metadata:
+                                source = 'INDUCKS'
+                                app_logger.info(f"Found metadata from INDUCKS for {filename}")
+                                return True
+                            note_near_miss('inducks', publication.get('name') or inducks_series_name,
+                                           {'provider': 'inducks', 'series_id': publication['id']})
+                        except Exception as e:
+                            app_logger.warning(f"INDUCKS lookup failed for {filename}: {e}")
+                        return False
+
                     def accept_match(try_fn):
                         """Run a provider lookup and validate what it returned.
 
@@ -1794,6 +1851,7 @@ def batch_metadata():
                         'comicvine': try_comicvine,
                         'gcd': try_gcd,
                         'gcd_api': try_gcd_api,
+                        'inducks': try_inducks,
                         'anilist': try_anilist,
                         'mangadex': try_mangadex,
                         'mangaupdates': try_mangaupdates,

--- a/routes/metadata.py
+++ b/routes/metadata.py
@@ -57,6 +57,7 @@ from core.comicinfo import generate_comicinfo_xml, _as_text  # noqa: F401
 
 from core.metadata_dates import (
     evaluate as evaluate_issue_date,
+    issue_year_from_filename,
     year_is_issue_level,
     MODE_ENFORCE as DATE_MODE_ENFORCE,
 )
@@ -1352,6 +1353,12 @@ def batch_metadata():
         # Store year for GCD lookups
         gcd_year = extracted_year or cvinfo_start_year
 
+        # One INDUCKS title lookup per distinct name across the whole job. The
+        # folder-derived names repeat for every file in the directory, and the
+        # search scans the publication table, so without this it would be run
+        # once per file for the same answer.
+        _inducks_searched = {}
+
         def generate():
             """Generator for SSE streaming."""
             result = {
@@ -1765,51 +1772,79 @@ def batch_metadata():
 
                     # Helper function for INDUCKS lookup (Disney material)
                     def try_inducks():
+                        """Resolve a Disney album against INDUCKS.
+
+                        Harder than the other providers for two reasons that
+                        pull in opposite directions. A Disney title names
+                        several runs at once -- eleven Italian publications
+                        reduce to the name "Topolino" -- so the title alone can
+                        never identify one. And these folders are filed by year
+                        rather than by publication ("Topolino anno 1975", "Anno
+                        1986 vol 1571-1622"), so the folder name often does not
+                        contain the title at all.
+
+                        So: try progressively looser names until one produces
+                        candidates, then let the issue number and the filename
+                        year choose between them. The loosening is safe because
+                        the narrowing is evidence, not preference -- of those
+                        eleven publications only one has an issue 1500.
+                        """
                         nonlocal metadata, source
                         if not inducks_available:
                             return False
                         try:
-                            inducks_series_name = os.path.basename(directory)
-                            # A four-digit year is noise, but a parenthetical
-                            # qualifier is not: INDUCKS uses exactly that form to
-                            # tell publications apart, and "Topolino (giornale)"
-                            # is a different publication from "Topolino".
-                            inducks_series_name = re.sub(r'\s*\(\d{4}\).*$', '', inducks_series_name)
-                            inducks_series_name = re.sub(r'\s*v\d+.*$', '', inducks_series_name).strip()
-                            if not inducks_series_name:
-                                return False
+                            folder_name = os.path.basename(directory)
+                            folder_name = re.sub(r'\s*\(\d{4}\).*$', '', folder_name).strip()
 
-                            candidates = inducks.search_series(inducks_series_name, gcd_year)
+                            names = [folder_name, inducks.strip_run_marker(folder_name)]
+                            # CLU's own filename parser, not a second one: the
+                            # folder is frequently a year rather than a series.
+                            try:
+                                from cbz_ops.rename import extract_comic_values
+                                parsed = (extract_comic_values(filename, width=0)
+                                          .get('series_name') or '').strip()
+                                if parsed:
+                                    names.append(parsed)
+                            except Exception:
+                                pass
+
+                            candidates = []
+                            for name in names:
+                                if not name:
+                                    continue
+                                if name not in _inducks_searched:
+                                    _inducks_searched[name] = inducks.search_series(name, gcd_year)
+                                candidates = _inducks_searched[name]
+                                if candidates:
+                                    break
+
                             if not candidates:
                                 return False
 
-                            if len(candidates) > 1 and gcd_year:
-                                # A folder year is evidence, not a tiebreak: two
-                                # runs published under the identical title are
-                                # told apart by when they started, which is
-                                # exactly the test core.bulk_metadata applies.
-                                dated = [c for c in candidates if c.get('year_began') == gcd_year]
-                                if len(dated) == 1:
-                                    candidates = dated
+                            narrowed = inducks.narrow_to_issue(
+                                candidates, issue_number,
+                                issue_year_from_filename(filename),
+                            )
 
-                            # Refuse to guess. The same Disney title names
-                            # several runs, and picking one arbitrarily is how a
-                            # library ends up confidently mislabelled -- the
-                            # review queue is the right answer here.
-                            if len(candidates) > 1:
+                            if len(narrowed) != 1:
                                 app_logger.info(
-                                    f"INDUCKS: '{inducks_series_name}' matches "
-                                    f"{len(candidates)} publications, skipping batch auto-select"
+                                    f"INDUCKS: '{names[0]}' #{issue_number} matches "
+                                    f"{len(narrowed)} of {len(candidates)} publications, "
+                                    f"skipping batch auto-select"
                                 )
+                                if len(candidates) == 1:
+                                    note_near_miss('inducks', candidates[0].get('name') or names[0],
+                                                   {'provider': 'inducks',
+                                                    'series_id': candidates[0]['id']})
                                 return False
 
-                            publication = candidates[0]
+                            publication = narrowed[0]
                             metadata = inducks.get_issue_metadata(publication['id'], issue_number)
                             if metadata:
                                 source = 'INDUCKS'
                                 app_logger.info(f"Found metadata from INDUCKS for {filename}")
                                 return True
-                            note_near_miss('inducks', publication.get('name') or inducks_series_name,
+                            note_near_miss('inducks', publication.get('name') or names[0],
                                            {'provider': 'inducks', 'series_id': publication['id']})
                         except Exception as e:
                             app_logger.warning(f"INDUCKS lookup failed for {filename}: {e}")

--- a/routes/metadata.py
+++ b/routes/metadata.py
@@ -1823,7 +1823,7 @@ def batch_metadata():
 
                             narrowed = inducks.narrow_to_issue(
                                 candidates, issue_number,
-                                issue_year_from_filename(filename),
+                                issue_year_from_filename(filename, issue_number),
                             )
 
                             if len(narrowed) != 1:
@@ -1866,7 +1866,7 @@ def batch_metadata():
                         if not try_fn():
                             return False
                         _mode, _conflict, _year = evaluate_issue_date(
-                            filename, _issue_date_of(metadata, source)
+                            filename, _issue_date_of(metadata, source), issue_number
                         )
                         if _conflict and _mode == DATE_MODE_ENFORCE:
                             app_logger.info(
@@ -3706,6 +3706,58 @@ def _try_gcd_single(series_name, issue_number, year):
         return None, None, None
 
 
+def _try_inducks_single(series_name, issue_number, year, file_name, near_misses=None):
+    """Try INDUCKS provider for a single file (Disney anthology material).
+
+    Mirrors the batch path's ``try_inducks`` (the only place this used to run
+    -- see the near-miss dead-end this closes): a Disney title can name
+    several runs at once, so candidates are narrowed by the issue number and,
+    where the filename claims one, the filename year, before fetching. When
+    exactly one series candidate exists but the issue can't be narrowed or
+    fetched from it, that's recorded into ``near_misses`` instead of just
+    failing, so the generic issue-picker fallback at the end of the cascade
+    can still resolve it.
+
+    Returns (metadata_dict, None, None) on success, or (None, None, None)
+    when nothing found or the series itself is ambiguous.
+    """
+    try:
+        if not inducks.check_database_status().get('inducks_available', False):
+            return None, None, None
+        if not series_name:
+            return None, None, None
+
+        candidates = inducks.search_series(series_name, year)
+        if not candidates:
+            return None, None, None
+
+        narrowed = inducks.narrow_to_issue(
+            candidates, issue_number,
+            issue_year_from_filename(file_name, issue_number),
+        )
+        if len(narrowed) != 1:
+            if len(candidates) == 1:
+                _record_near_miss(
+                    near_misses, 'inducks', candidates[0].get('name') or series_name,
+                    {'provider': 'inducks', 'series_id': candidates[0]['id']},
+                )
+            return None, None, None
+
+        publication = narrowed[0]
+        metadata = inducks.get_issue_metadata(publication['id'], issue_number)
+        if metadata:
+            return metadata, None, None
+
+        _record_near_miss(
+            near_misses, 'inducks', publication.get('name') or series_name,
+            {'provider': 'inducks', 'series_id': publication['id']},
+        )
+        return None, None, None
+    except Exception as e:
+        app_logger.warning(f"[search-metadata] INDUCKS lookup failed: {e}")
+        return None, None, None
+
+
 def _resolve_gcd_api_start_year(file_path, series_name):
     """Try to find the series start year from folder name or sibling ComicInfo.xml.
 
@@ -4205,6 +4257,11 @@ def search_metadata():
                         img_url = api_metadata.pop('_cover_url', None)
                         metadata = api_metadata
 
+            elif provider == 'inducks':
+                series_id = selected_match.get('series_id')
+                if series_id:
+                    metadata = inducks.get_issue_metadata(series_id, issue_number)
+
             elif provider in ('anilist', 'mangadex', 'mangaupdates'):
                 series_id = selected_match.get('series_id')
                 preferred_title = selected_match.get('preferred_title')
@@ -4306,6 +4363,10 @@ def search_metadata():
                     provider_order.append('gcd_api')
             except Exception:
                 pass
+            # Mirrors the batch path's default order (routes/metadata.py's
+            # batch handler above), which already includes inducks here.
+            if inducks.check_database_status().get('inducks_available', False):
+                provider_order.append('inducks')
 
         # Restrict to a single provider when requested (per-provider refine).
         if only_provider:
@@ -4405,6 +4466,12 @@ def search_metadata():
                     app_logger.info(f"[search-metadata] {provider_type} requires selection for {file_name}")
                     return jsonify(selection_data)
 
+            elif provider_type == 'inducks':
+                metadata, img_url, _ = _try_inducks_single(
+                    series_name, issue_number, year, file_name,
+                    near_misses=near_misses
+                )
+
             elif provider_type in ('anilist', 'mangadex', 'mangaupdates'):
                 # Manga providers: clean series name and search
                 manga_series_name = re.sub(r'\s*\(\d{4}\).*$', '', series_name)
@@ -4478,7 +4545,7 @@ def search_metadata():
                 # filename. The selection follow-up above is exempt — there the
                 # user picked the series themselves.
                 _dc_mode, _dc_conflict, _dc_year = evaluate_issue_date(
-                    file_name, _issue_date_of(metadata, provider_type)
+                    file_name, _issue_date_of(metadata, provider_type), issue_number
                 )
                 if _dc_conflict and _dc_mode == DATE_MODE_ENFORCE:
                     app_logger.info(

--- a/templates/config.html
+++ b/templates/config.html
@@ -3528,7 +3528,7 @@
             }
 
             // Define custom display order (MangaUpdates takes AniList's old slot)
-            const providerOrder = ['metron', 'comicvine', 'comicvine_sqlite', 'gcd', 'mangaupdates', 'bedetheque', 'mangadex'];
+            const providerOrder = ['metron', 'comicvine', 'comicvine_sqlite', 'gcd', 'inducks', 'mangaupdates', 'bedetheque', 'mangadex'];
             const sortedProviders = [...data.providers]
                 .filter(p => p.type !== 'anilist')
                 .sort((a, b) => {
@@ -3637,6 +3637,34 @@
                         </small>
                     </div>` : '';
 
+                const inducksExtra = provider.type === 'inducks' ? `
+                    <div class="mt-2">
+                        <small class="form-text text-muted">
+                            INDUCKS indexes Disney comics worldwide, including the European and
+                            South American publishing the other providers do not cover. Build the
+                            SQLite database from the dumps at
+                            <a href="https://inducks.org/" target="_blank" rel="noopener">inducks.org</a>,
+                            place it on a mapped path, and enter its full path above
+                            (e.g. <code>/config/inducks.db</code>). The file is around 700&nbsp;MB and
+                            is read directly from disk, not uploaded.
+                        </small>
+                    </div>
+                    <div class="mt-3 pt-3 border-top">
+                        <label for="inducksCountries" class="form-label">Publication Countries</label>
+                        <div class="input-group input-group-sm">
+                            <input type="text" id="inducksCountries" class="form-control form-control-sm"
+                                   placeholder="us" value="">
+                            <button type="button" class="btn btn-primary btn-sm" onclick="saveInducksCountries()">
+                                <i class="bi bi-floppy me-1"></i>Save
+                            </button>
+                        </div>
+                        <small class="form-text text-muted">
+                            Comma-separated country codes (e.g., "it,fr,se"). Default: "us".
+                            The same Disney title is published in dozens of countries, so without
+                            this nearly every lookup is ambiguous.
+                        </small>
+                    </div>` : '';
+
                 const cvSqliteExtra = provider.type === 'comicvine_sqlite' ? `
                     <div class="mt-2">
                         <small class="form-text text-muted">
@@ -3675,13 +3703,14 @@
                                 ${cardBody}
                                 ${gcdExtra}
                                 ${cvSqliteExtra}
+                                ${inducksExtra}
                                 ${lastTested}
                             </div>
                             ${metronAttribution}
                             <div class="card-footer text-muted small" id="provider-footer-${provider.type}">
                                 ${provider.type === 'gcd' && provider.is_valid
                                     ? '<span class="spinner-border spinner-border-sm me-1"></span>Loading database stats...'
-                                    : (provider.type === 'gcd' || provider.type === 'comicvine_sqlite')
+                                    : (provider.type === 'gcd' || provider.type === 'comicvine_sqlite' || provider.type === 'inducks')
                                         ? 'Local SQLite database'
                                         : `Rate limit: ${provider.rate_limit} requests/minute`}
                             </div>
@@ -3695,6 +3724,7 @@
             initPasswordToggles(container);
             // Load GCD language preference into the field
             loadGcdLanguages();
+            loadInducksCountries();
             loadGcdStats();
         } catch (e) {
             container.innerHTML = '<div class="alert alert-danger">Error loading providers: ' + escapeHtml(e.message) + '</div>';
@@ -3776,6 +3806,39 @@
             }
         } catch (e) {
             showToast('Error saving GCD languages: ' + e.message, 'error');
+        }
+    }
+
+    async function loadInducksCountries() {
+        const input = document.getElementById('inducksCountries');
+        if (!input) return;
+        try {
+            const resp = await fetch('/api/preferences/inducks_countries');
+            const data = await resp.json();
+            input.value = (data.success && data.value) ? data.value : 'us';
+        } catch (e) {
+            input.value = 'us';
+        }
+    }
+
+    async function saveInducksCountries() {
+        const input = document.getElementById('inducksCountries');
+        if (!input) return;
+        const value = input.value.trim() || 'us';
+        try {
+            const resp = await fetch('/api/preferences/inducks_countries', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ value: value, category: 'metadata' })
+            });
+            const data = await resp.json();
+            if (data.success) {
+                showToast('INDUCKS country preference saved', 'success');
+            } else {
+                showToast('Error saving INDUCKS countries: ' + (data.error || 'Unknown error'), 'error');
+            }
+        } catch (e) {
+            showToast('Error saving INDUCKS countries: ' + e.message, 'error');
         }
     }
 

--- a/templates/metadata_history.html
+++ b/templates/metadata_history.html
@@ -22,6 +22,7 @@
             <option value="comicvine">ComicVine</option>
             <option value="gcd">GCD</option>
             <option value="gcd_api">GCD API</option>
+            <option value="inducks">INDUCKS</option>
             <option value="anilist">AniList</option>
             <option value="mangadex">MangaDex</option>
             <option value="mangaupdates">MangaUpdates</option>

--- a/tests/mocked/conftest.py
+++ b/tests/mocked/conftest.py
@@ -524,6 +524,17 @@ def build_inducks_sqlite(path, *, core_only=False):
             ("it/ZP", "it", "it", "Zio Paperone"),
             ("xx/UN", "it", "it", "Senza data"),
             ("us/WDC", "us", "en", "Walt Disney's Comics and Stories"),
+            # A run that continues under a "(seconda serie)": both are indexed
+            # under the same stripped title, and only the issue number says
+            # which one holds a given album.
+            ("it/SA", "it", "it", "Super Almanacco Paperino"),
+            ("it/SAP", "it", "it", "Super Almanacco Paperino (seconda serie)"),
+            # The ordinal spelled the way INDUCKS spells it, against the "II
+            # Serie" a folder uses.
+            ("it/GCDN", "it", "it", "I Grandi Classici Disney (Seconda Serie)"),
+            # INDUCKS says "storie Disney" where the scene says "storie di Walt
+            # Disney" -- the same words, one preposition apart.
+            ("it/GSD", "it", "it", "Le grandi storie Disney - L'opera omnia di Romano Scarpa"),
         ],
     )
 
@@ -542,6 +553,12 @@ def build_inducks_sqlite(path, *, core_only=False):
             ("it/ZP    1", "it/ZP", "1", "", "100", "", "1987-01-01"),
             ("xx/UN    1", "xx/UN", "1", "", "", "", ""),
             ("us/WDC   1", "us/WDC", "1", "", "64", "", "1940-10-01"),
+            ("it/SA    1", "it/SA", "1", "", "100", "", "1976-12-01"),
+            ("it/SA    2", "it/SA", "2", "", "100", "", "1977-04-01"),
+            ("it/SAP   3", "it/SAP", "3", "", "100", "", "1980-06-01"),
+            ("it/SAP   4", "it/SAP", "4", "", "100", "", "1980-09-01"),
+            ("it/GCDN  1", "it/GCDN", "1", "", "160", "", "1996-01-01"),
+            ("it/GSD   1", "it/GSD", "1", "", "200", "", "2014-01-01"),
         ],
     )
 

--- a/tests/mocked/conftest.py
+++ b/tests/mocked/conftest.py
@@ -447,3 +447,191 @@ def comicvine_sqlite_configured(comicvine_sqlite_db_path, monkeypatch):
     return str(comicvine_sqlite_db_path)
 
 
+
+
+# ---------------------------------------------------------------------------
+# INDUCKS SQLite test database
+#
+# The INDUCKS provider reads a user-built SQLite database. As with GCD, these
+# fixtures build a tiny real file rather than mocking cursors, so the SQL is
+# actually exercised -- which matters more here than usual: the start-year
+# derivation has a trap in it that only real rows can catch.
+# ---------------------------------------------------------------------------
+
+def build_inducks_sqlite(path, *, core_only=False):
+    """Create a minimal INDUCKS SQLite database at `path`.
+
+    Models the two shapes that matter:
+
+    * ``it/TL`` "Topolino (libretto)" -- an anthology issue with two stories, a
+      cover that must NOT contribute credits, per-story writers, pencillers and
+      characters, and an issue set whose ``oldestdate`` values include both an
+      empty string and the ``9999-12-31`` unknown sentinel. That is the exact
+      shape a naive ``MIN(SUBSTR(oldestdate, 1, 4))`` gets wrong.
+    * ``it/TG`` "Topolino (giornale)" -- a second publication whose
+      qualifier-stripped title collides with the first, so the bare name
+      "Topolino" is ambiguous and the stripped name is not usable as a Series.
+
+    ``xx/UN`` has no usable date at all, for the year=None path.
+    """
+    import sqlite3
+    conn = sqlite3.connect(str(path))
+    cur = conn.cursor()
+    cur.executescript(
+        """
+        CREATE TABLE inducks_publication (
+            publicationcode TEXT PRIMARY KEY, countrycode TEXT,
+            languagecode TEXT, title TEXT
+        );
+        CREATE TABLE inducks_issue (
+            issuecode TEXT PRIMARY KEY, publicationcode TEXT, issuenumber TEXT,
+            title TEXT, pages TEXT, price TEXT, oldestdate TEXT
+        );
+        CREATE TABLE inducks_issuedate (issuecode TEXT, date TEXT, kindofdate TEXT);
+        CREATE TABLE inducks_entry (
+            entrycode TEXT PRIMARY KEY, issuecode TEXT, storyversioncode TEXT,
+            position TEXT, title TEXT
+        );
+        CREATE TABLE inducks_storyversion (
+            storyversioncode TEXT PRIMARY KEY, storycode TEXT, kind TEXT
+        );
+        CREATE TABLE inducks_storyjob (
+            storyversioncode TEXT, personcode TEXT, plotwritartink TEXT
+        );
+        CREATE TABLE inducks_character (charactercode TEXT PRIMARY KEY, charactername TEXT);
+        """
+    )
+    if not core_only:
+        cur.executescript(
+            """
+            CREATE TABLE inducks_story (storycode TEXT PRIMARY KEY, title TEXT);
+            CREATE TABLE inducks_person (personcode TEXT PRIMARY KEY, fullname TEXT);
+            CREATE TABLE inducks_publisher (publisherid TEXT PRIMARY KEY, publishername TEXT);
+            CREATE TABLE inducks_publishingjob (publisherid TEXT, issuecode TEXT);
+            CREATE TABLE inducks_appearance (storyversioncode TEXT, charactercode TEXT);
+            CREATE TABLE inducks_charactername (
+                charactercode TEXT, languagecode TEXT, charactername TEXT, preferred TEXT
+            );
+            """
+        )
+
+    cur.executemany(
+        "INSERT INTO inducks_publication (publicationcode, countrycode, languagecode, title) "
+        "VALUES (?, ?, ?, ?)",
+        [
+            ("it/TL", "it", "it", "Topolino (libretto)"),
+            ("it/TG", "it", "it", "Topolino (giornale)"),
+            ("it/ZP", "it", "it", "Zio Paperone"),
+            ("xx/UN", "it", "it", "Senza data"),
+            ("us/WDC", "us", "en", "Walt Disney's Comics and Stories"),
+        ],
+    )
+
+    cur.executemany(
+        "INSERT INTO inducks_issue (issuecode, publicationcode, issuenumber, title, "
+        "pages, price, oldestdate) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        [
+            # The empty string sorts before every real date, and 9999-12-31 is
+            # INDUCKS' "unknown". Both must be excluded before MIN() sees them,
+            # or it/TL reports no start year at all.
+            ("it/TL    1", "it/TL", "1", "Il primo numero", "68", "", "1949-04-07"),
+            ("it/TL    2", "it/TL", "2", "", "68", "", ""),
+            ("it/TL    3", "it/TL", "3", "", "68", "", "9999-12-31"),
+            ("it/TL 3200", "it/TL", "3200", "", "164", "", "2017-06-27"),
+            ("it/TG    1", "it/TG", "1", "", "8", "", "1932-12-31"),
+            ("it/ZP    1", "it/ZP", "1", "", "100", "", "1987-01-01"),
+            ("xx/UN    1", "xx/UN", "1", "", "", "", ""),
+            ("us/WDC   1", "us/WDC", "1", "", "64", "", "1940-10-01"),
+        ],
+    )
+
+    # A more precise date than oldestdate, which is what the model prefers.
+    cur.executemany(
+        "INSERT INTO inducks_issuedate (issuecode, date, kindofdate) VALUES (?, ?, ?)",
+        [("it/TL    1", "1949-04-07", "d"), ("it/TL 3200", "2017-06-27", "d")],
+    )
+
+    # Issue 1 of it/TL: a cover plus two stories. The cover's artist must not
+    # reach ComicInfo -- a cover artist is not the penciller of the book.
+    cur.executemany(
+        "INSERT INTO inducks_entry (entrycode, issuecode, storyversioncode, position, title) "
+        "VALUES (?, ?, ?, ?, ?)",
+        [
+            ("e1", "it/TL    1", "sv-cover", "1", ""),
+            ("e2", "it/TL    1", "sv-a", "2", "Topolino e il cobra bianco"),
+            ("e3", "it/TL    1", "sv-b", "3", "Paperino e il ladro di uova"),
+        ],
+    )
+    cur.executemany(
+        "INSERT INTO inducks_storyversion (storyversioncode, storycode, kind) VALUES (?, ?, ?)",
+        [("sv-cover", "st-cover", "c"), ("sv-a", "st-a", "n"), ("sv-b", "st-b", "n")],
+    )
+    cur.executemany(
+        "INSERT INTO inducks_storyjob (storyversioncode, personcode, plotwritartink) "
+        "VALUES (?, ?, ?)",
+        [
+            ("sv-cover", "p-cover", "a"),
+            ("sv-a", "p-bottaro", "w"),
+            ("sv-a", "p-bottaro", "a"),
+            ("sv-b", "p-scarpa", "w"),
+            ("sv-b", "p-cavazzano", "a"),
+            ("sv-b", "p-inker", "i"),
+        ],
+    )
+    cur.executemany(
+        "INSERT INTO inducks_character (charactercode, charactername) VALUES (?, ?)",
+        [("c-mm", "Mickey Mouse"), ("c-dd", "Donald Duck")],
+    )
+
+    if not core_only:
+        cur.executemany("INSERT INTO inducks_story (storycode, title) VALUES (?, ?)",
+                        [("st-cover", ""), ("st-a", "Topolino e il cobra bianco"),
+                         ("st-b", "Paperino e il ladro di uova")])
+        cur.executemany("INSERT INTO inducks_person (personcode, fullname) VALUES (?, ?)",
+                        [("p-bottaro", "Luciano Bottaro"), ("p-scarpa", "Romano Scarpa"),
+                         ("p-cavazzano", "Giorgio Cavazzano"), ("p-inker", "Sandro Zemolin"),
+                         ("p-cover", "Coverist")])
+        cur.executemany("INSERT INTO inducks_publisher (publisherid, publishername) VALUES (?, ?)",
+                        [("mondadori", "Arnoldo Mondadori Editore"),
+                         ("panini", "Panini Comics")])
+        # Two publishers on one issue, oldest first: the last row is the imprint
+        # that actually produced it.
+        cur.executemany("INSERT INTO inducks_publishingjob (publisherid, issuecode) VALUES (?, ?)",
+                        [("mondadori", "it/TL    1"), ("panini", "it/TL    1")])
+        cur.executemany("INSERT INTO inducks_appearance (storyversioncode, charactercode) VALUES (?, ?)",
+                        [("sv-a", "c-mm"), ("sv-b", "c-dd"), ("sv-cover", "c-mm")])
+        cur.executemany(
+            "INSERT INTO inducks_charactername (charactercode, languagecode, charactername, preferred) "
+            "VALUES (?, ?, ?, ?)",
+            [("c-mm", "it", "Topolino", "Y"), ("c-dd", "it", "Paperino", "Y"),
+             ("c-dd", "it", "Paolino Paperino", "N")],
+        )
+
+    conn.commit()
+    conn.close()
+    return str(path)
+
+
+@pytest.fixture
+def inducks_db_path(tmp_path):
+    """Path to a fully-populated INDUCKS SQLite test database."""
+    return build_inducks_sqlite(tmp_path / "inducks.db")
+
+
+@pytest.fixture
+def inducks_creds(inducks_db_path):
+    return ProviderCredentials(database_path=str(inducks_db_path))
+
+
+@pytest.fixture
+def inducks_configured(inducks_db_path, monkeypatch):
+    """Point models.inducks at the test database, scoped to Italy."""
+    import models.inducks as inducks_module
+    inducks_module.invalidate_inducks_table_cache()
+    monkeypatch.setattr(
+        "models.inducks._get_saved_credentials",
+        lambda: {"database_path": str(inducks_db_path)},
+    )
+    monkeypatch.setattr("models.inducks.get_configured_countries", lambda: ["it"])
+    yield str(inducks_db_path)
+    inducks_module.invalidate_inducks_table_cache()

--- a/tests/mocked/test_inducks_provider.py
+++ b/tests/mocked/test_inducks_provider.py
@@ -295,6 +295,75 @@ class TestNarrowToIssue:
         assert "9999" not in found
 
 
+class TestIssueNumberPaddingSymmetry:
+    """narrow_to_issue and get_issue_metadata used to normalize issue numbers
+    differently -- a publication narrow_to_issue accepted on a padded number
+    could return None when fetched through get_issue_metadata on the unpadded
+    form, or vice versa. Both now key off models.inducks._normalize_issue_number.
+    """
+
+    @pytest.mark.parametrize("query", ["1", "01", "001", "0001"])
+    def test_get_issue_metadata_accepts_every_padding_of_an_unpadded_row(
+        self, inducks_configured, query
+    ):
+        """it/TL stores issue 1 unpadded ("1"); every width CLU might supply
+        must still resolve to it."""
+        from models.inducks import get_issue_metadata
+
+        md = get_issue_metadata("it/TL", query)
+        assert md is not None
+        assert md["Number"] == "1"
+
+    @pytest.mark.parametrize("query", ["3200", "03200"])
+    def test_narrow_to_issue_and_get_issue_metadata_agree(self, inducks_configured, query):
+        """The exact regression from the PR review: narrow_to_issue accepts
+        '03200' against it/TL, but the un-fixed get_issue_metadata('it/TL',
+        '03200') returned None -- a real near-miss dead-end."""
+        from models.inducks import search_series, narrow_to_issue, get_issue_metadata
+
+        candidates = search_series("Topolino")
+        narrowed = narrow_to_issue(candidates, query)
+        assert [c["id"] for c in narrowed] == ["it/TL"]
+        assert get_issue_metadata(narrowed[0]["id"], query) is not None
+
+    def _add_padded_publication(self, inducks_db_path):
+        """The shared fixture only ever stores unpadded issue numbers. Add a
+        publication whose issuenumber column is genuinely zero-padded, the
+        direction the shared fixture can't otherwise exercise."""
+        conn = sqlite3.connect(str(inducks_db_path))
+        conn.execute(
+            "INSERT INTO inducks_publication (publicationcode, countrycode, "
+            "languagecode, title) VALUES (?, ?, ?, ?)",
+            ("it/PAD", "it", "it", "Paperinik Padded"),
+        )
+        conn.execute(
+            "INSERT INTO inducks_issue (issuecode, publicationcode, "
+            "issuenumber, title, pages, price, oldestdate) VALUES "
+            "(?, ?, ?, ?, ?, ?, ?)",
+            ("it/PAD    7", "it/PAD", "0007", "", "32", "", "2001-01-01"),
+        )
+        conn.commit()
+        conn.close()
+
+    @pytest.mark.parametrize("query", ["7", "07", "007", "0007"])
+    def test_padded_storage_fetched_by_every_query_width(
+        self, inducks_configured, inducks_db_path, query
+    ):
+        from models.inducks import get_issue_metadata
+
+        self._add_padded_publication(inducks_db_path)
+        md = get_issue_metadata("it/PAD", query)
+        assert md is not None
+        assert md["Number"] == "0007"
+
+    def test_padded_storage_narrows_on_an_unpadded_query(self, inducks_configured, inducks_db_path):
+        from models.inducks import search_series, narrow_to_issue
+
+        self._add_padded_publication(inducks_db_path)
+        candidates = search_series("Paperinik Padded")
+        assert [c["id"] for c in narrow_to_issue(candidates, "7")] == ["it/PAD"]
+
+
 class TestRelaxedTitleMatching:
 
     def test_ordinal_spelled_the_other_way(self, inducks_configured):
@@ -396,6 +465,54 @@ class TestGetIssueMetadata:
         assert get_issue_metadata("it/TL", "9999") is None
         assert get_issue_metadata("it/TL", "") is None
         assert get_issue_metadata("", "1") is None
+
+    def test_publisher_order_survives_an_index_backed_scan(self, tmp_path):
+        """The old query had no ORDER BY, so 'the last row wins' silently
+        depended on SQLite happening to walk the table in insertion order.
+        The bare-table fixture used everywhere else can never disagree with
+        that -- this builds a covering index on (issuecode, publisherid),
+        which the planner prefers over a table scan (confirmed via EXPLAIN
+        QUERY PLAN) and which visits publisherid alphabetically. Choosing
+        publisherid values that sort opposite to insertion order makes the
+        unordered scan return the WRONG publisher last; the explicit
+        ``ORDER BY j.rowid`` in _publisher must still return the right one.
+        """
+        from models.inducks import _publisher, _dict_factory
+
+        path = str(tmp_path / "publisher_order.db")
+        conn = sqlite3.connect(path)
+        conn.executescript(
+            """
+            CREATE TABLE inducks_publisher (publisherid TEXT PRIMARY KEY, publishername TEXT);
+            CREATE TABLE inducks_publishingjob (publisherid TEXT, issuecode TEXT);
+            """
+        )
+        conn.executemany(
+            "INSERT INTO inducks_publisher (publisherid, publishername) VALUES (?, ?)",
+            [("zzz_old", "Arnoldo Mondadori Editore"), ("aaa_new", "Panini Comics")],
+        )
+        # Inserted oldest-first, matching the docstring's "listed oldest
+        # first" and giving "aaa_new" (Panini, the modern imprint) the
+        # higher rowid -- the correct answer is the last-INSERTED row.
+        conn.executemany(
+            "INSERT INTO inducks_publishingjob (publisherid, issuecode) VALUES (?, ?)",
+            [("zzz_old", "it/TL    1"), ("aaa_new", "it/TL    1")],
+        )
+        # This index lets an unordered scan visit "aaa_new" before
+        # "zzz_old" (alphabetical), the reverse of insertion order.
+        conn.execute(
+            "CREATE INDEX idx_publishingjob_issuecode "
+            "ON inducks_publishingjob (issuecode, publisherid)"
+        )
+        conn.commit()
+        conn.close()
+
+        ro_conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+        ro_conn.row_factory = _dict_factory
+        try:
+            assert _publisher(ro_conn, "it/TL    1") == "Panini Comics"
+        finally:
+            ro_conn.close()
 
     def test_incomplete_build_is_rejected_not_silently_degraded(self, tmp_path, monkeypatch):
         """A build missing tables must fail the connection test, loudly.
@@ -532,9 +649,126 @@ class TestDateCheckIntegration:
         assert date_conflict(1949, md["Year"], tolerance=2) is True
         assert date_conflict(2017, md["Year"], tolerance=2) is False
 
+    def _add_issue_2000(self, inducks_db_path, oldestdate="1993-05-01"):
+        """it/TL numbered past #3600 in reality; add a #2000 issue so a
+        filename literally named 'Topolino 2000.cbz' is realistic."""
+        conn = sqlite3.connect(str(inducks_db_path))
+        conn.execute(
+            "INSERT INTO inducks_issue (issuecode, publicationcode, "
+            "issuenumber, title, pages, price, oldestdate) VALUES "
+            "(?, ?, ?, ?, ?, ?, ?)",
+            ("it/TL 2000", "it/TL", "2000", "", "164", "", oldestdate),
+        )
+        conn.commit()
+        conn.close()
+
+    def test_bare_filename_year_equal_to_the_issue_number_is_accepted(
+        self, inducks_configured, inducks_db_path, monkeypatch
+    ):
+        """The bug this closes: Topolino issue numbers run past #3600, so
+        'Topolino 2000.cbz' reads as both a plausible year (2000) and the
+        issue number, 18+ years from the real 1993 publication date --
+        past tolerance, so date_check_mode=enforce discarded a correct match
+        for every issue numbered 1900-2099 before the exemption existed.
+        """
+        from core.metadata_dates import evaluate
+        from models.inducks import get_issue_metadata
+
+        self._add_issue_2000(inducks_db_path)
+        md = get_issue_metadata("it/TL", "2000")
+        assert md["Year"] == 1993
+
+        monkeypatch.setattr("core.metadata_dates.date_check_mode", lambda: "enforce")
+        monkeypatch.setattr("core.metadata_dates.date_check_tolerance", lambda: 2)
+        _mode, conflicted, _year = evaluate(
+            "Topolino 2000.cbz", md["Year"], issue_number="2000"
+        )
+        assert conflicted is False
+
+    def test_filename_year_alongside_the_issue_number_still_short_circuits(
+        self, inducks_configured, monkeypatch
+    ):
+        """Regression guard: 'Topolino 1975 (1993).cbz' already carries two
+        distinct plausible years (1975 and 1993) and was already unresolved
+        (no check ran) before the exemption -- it must stay that way rather
+        than being narrowed down to 1993 by the issue_number exemption.
+        """
+        from core.metadata_dates import evaluate
+
+        monkeypatch.setattr("core.metadata_dates.date_check_mode", lambda: "enforce")
+        monkeypatch.setattr("core.metadata_dates.date_check_tolerance", lambda: 2)
+        _mode, conflicted, filename_year = evaluate(
+            "Topolino 1975 (1993).cbz", "1993", issue_number="1975"
+        )
+        assert conflicted is False
+        assert filename_year is None
+
     def test_country_preference_default(self, monkeypatch):
         from models.inducks import get_configured_countries
 
         monkeypatch.setattr("core.database.get_user_preference",
                             lambda *a, **k: None, raising=False)
         assert get_configured_countries() == ["us"]
+
+
+class TestCollidingTitlesCache:
+    """search_series computes _colliding_stripped_titles once and threads it
+    through via the `colliding` parameter -- get_issue_metadata does not, so
+    every call re-scanned the whole publication table (7,310 rows on the real
+    build, each put through normalize_title's NFKD decomposition) via
+    series_name_for. Cached at module scope instead, invalidated alongside
+    the existing table cache.
+    """
+
+    SCAN_SQL = "SELECT title FROM inducks_publication WHERE title IS NOT NULL AND title <> ''"
+
+    def test_scan_runs_once_across_repeated_get_issue_metadata_calls(
+        self, inducks_configured, monkeypatch
+    ):
+        """sqlite3.Cursor is a C type and can't be monkeypatched directly, so
+        this spies via sqlite3's own trace callback on the connections
+        models.inducks opens."""
+        import models.inducks as inducks_module
+
+        inducks_module._COLLIDING_TITLES_CACHE = None
+        calls = {"n": 0}
+        real_get_connection = inducks_module.get_connection
+
+        def traced_get_connection():
+            conn = real_get_connection()
+            if conn is not None:
+                def _trace(sql):
+                    if sql.strip() == self.SCAN_SQL:
+                        calls["n"] += 1
+                conn.set_trace_callback(_trace)
+            return conn
+
+        monkeypatch.setattr(inducks_module, "get_connection", traced_get_connection)
+
+        inducks_module.get_issue_metadata("it/TL", "1")
+        inducks_module.get_issue_metadata("it/TL", "3200")
+        inducks_module.get_issue_metadata("it/TG", "1")
+
+        assert calls["n"] == 1
+
+    def test_search_series_and_get_issue_metadata_share_the_cache(self, inducks_configured):
+        """search_series already computes this once per call; the two paths
+        must not each maintain their own copy."""
+        import models.inducks as inducks_module
+
+        inducks_module._COLLIDING_TITLES_CACHE = None
+        inducks_module.search_series("Topolino")
+        populated = inducks_module._COLLIDING_TITLES_CACHE
+        assert populated is not None
+
+        inducks_module.get_issue_metadata("it/TL", "1")
+        assert inducks_module._COLLIDING_TITLES_CACHE is populated
+
+    def test_invalidate_table_cache_also_clears_it(self, inducks_configured):
+        import models.inducks as inducks_module
+
+        inducks_module.get_issue_metadata("it/TL", "1")
+        assert inducks_module._COLLIDING_TITLES_CACHE is not None
+
+        inducks_module.invalidate_inducks_table_cache()
+        assert inducks_module._COLLIDING_TITLES_CACHE is None

--- a/tests/mocked/test_inducks_provider.py
+++ b/tests/mocked/test_inducks_provider.py
@@ -183,6 +183,148 @@ class TestSearchSeries:
         assert search_series("Zio Paperone")[0]["name"] == "Zio Paperone"
 
 
+class TestNameNormalisation:
+    """A Disney folder is named after a slice of a run far more often than
+    after the publication, and INDUCKS spells the run marker differently again."""
+
+    def test_strip_run_marker(self):
+        from models.inducks import strip_run_marker
+
+        assert strip_run_marker("Topolino anno 1975") == "Topolino"
+        assert strip_run_marker("Topolino Anno 1984 voilumi 1466-1518") == "Topolino"
+        # Nothing but markers: the folder names a slice of a run and no
+        # publication at all, so the caller has to fall back to the filename.
+        assert strip_run_marker("Anno 1986 vol 1571-1622") == ""
+        assert strip_run_marker("Albo d'oro v2") == "Albo d'oro"
+        assert strip_run_marker("Diabolik 001-100") == "Diabolik"
+        assert strip_run_marker("Anno 1970 - numeri 736-787  Repack") == ""
+
+    def test_strip_run_marker_leaves_a_real_title_alone(self):
+        """The marker only ever sits at the end, and a title that ends in a
+        number is a title."""
+        from models.inducks import strip_run_marker
+
+        assert strip_run_marker("Topolino 1000") == "Topolino 1000"
+        assert strip_run_marker("Topolino (libretto)") == "Topolino (libretto)"
+        assert strip_run_marker("100 Anni di Fumetto Italiano") == "100 Anni di Fumetto Italiano"
+
+    def test_normalise_ordinals(self):
+        from models.inducks import normalise_ordinals
+
+        assert normalise_ordinals("i grandi classici disney ii serie") == \
+            "i grandi classici disney seconda serie"
+        assert normalise_ordinals("i classici di walt disney 2a serie") == \
+            "i classici di walt disney seconda serie"
+        # Only the token before "serie" is an ordinal; a leading article is not.
+        assert normalise_ordinals("i classici disney") == "i classici disney"
+
+    def test_significant_tokens_drop_articles_and_walt(self):
+        from models.inducks import significant_tokens, normalize_title
+
+        assert (significant_tokens(normalize_title("Le grandi storie di Walt Disney"))
+                == significant_tokens(normalize_title("Le grandi storie Disney")))
+        # "disney" is never dropped: it is what separates these from everything
+        # else in a library.
+        assert "disney" in significant_tokens(normalize_title("Le grandi storie Disney"))
+
+
+class TestNarrowToIssue:
+    """The issue number is evidence the caller already has, and it is what makes
+    a loose name safe to try."""
+
+    def test_issue_number_picks_one_of_eleven(self, inducks_configured):
+        from models.inducks import search_series, narrow_to_issue
+
+        candidates = search_series("Topolino")
+        assert len(candidates) == 2
+        # Only it/TL ever had an issue 3200.
+        assert [c["id"] for c in narrow_to_issue(candidates, "3200")] == ["it/TL"]
+
+    def test_padded_numbers_match(self, inducks_configured):
+        from models.inducks import search_series, narrow_to_issue
+
+        candidates = search_series("Topolino")
+        assert [c["id"] for c in narrow_to_issue(candidates, "03200")] == ["it/TL"]
+
+    def test_a_run_continuing_into_a_second_series(self, inducks_configured):
+        """Both publications are indexed under the same stripped title, so the
+        issue number is the only thing that says which holds the album."""
+        from models.inducks import search_series, narrow_to_issue
+
+        candidates = search_series("Super Almanacco Paperino")
+        assert {c["id"] for c in candidates} == {"it/SA", "it/SAP"}
+        assert [c["id"] for c in narrow_to_issue(candidates, "1")] == ["it/SA"]
+        assert [c["id"] for c in narrow_to_issue(candidates, "3")] == ["it/SAP"]
+
+    def test_missing_issue_narrows_to_nothing(self, inducks_configured):
+        """Better than answering with the wrong run: the caller declines and the
+        next provider gets its turn."""
+        from models.inducks import search_series, narrow_to_issue
+
+        candidates = search_series("Super Almanacco Paperino")
+        assert narrow_to_issue(candidates, "99") == []
+
+    def test_year_separates_two_runs_holding_the_same_number(self, inducks_configured):
+        from models.inducks import search_series, narrow_to_issue
+
+        candidates = search_series("Topolino")
+        assert [c["id"] for c in narrow_to_issue(candidates, "1", 1949)] == ["it/TL"]
+        assert [c["id"] for c in narrow_to_issue(candidates, "1", 1932)] == ["it/TG"]
+
+    def test_ambiguity_survives_when_nothing_separates_them(self, inducks_configured):
+        """Both Topolinos have an issue 1 and no year is offered. Two survivors
+        is the honest answer."""
+        from models.inducks import search_series, narrow_to_issue
+
+        candidates = search_series("Topolino")
+        assert len(narrow_to_issue(candidates, "1")) == 2
+
+    def test_no_issue_number_changes_nothing(self, inducks_configured):
+        from models.inducks import search_series, narrow_to_issue
+
+        candidates = search_series("Topolino")
+        assert narrow_to_issue(candidates, "") == candidates
+
+    def test_issue_dates(self, inducks_configured):
+        from models.inducks import issue_dates
+
+        found = issue_dates("it/TL", ["1", "3200", "0002", "9999"])
+        assert found["1"] == "1949-04-07"
+        assert found["3200"] == "2017-06-27"
+        assert found["2"] is None  # present, but with no usable date
+        assert "9999" not in found
+
+
+class TestRelaxedTitleMatching:
+
+    def test_ordinal_spelled_the_other_way(self, inducks_configured):
+        """A folder says "II Serie" where INDUCKS says "(Seconda Serie)"."""
+        from models.inducks import search_series
+
+        assert [r["id"] for r in search_series("I grandi classici Disney II Serie")] == ["it/GCDN"]
+        assert [r["id"] for r in search_series("I Grandi Classici Disney 2a serie")] == ["it/GCDN"]
+
+    def test_same_words_one_preposition_apart(self, inducks_configured):
+        from models.inducks import search_series
+
+        assert [r["id"] for r in search_series(
+            "Le grandi storie di Walt Disney - L'opera omnia di Romano Scarpa")] == ["it/GSD"]
+
+    def test_token_match_needs_the_whole_set(self, inducks_configured):
+        """A subset must not match, or it becomes a fuzzy search."""
+        from models.inducks import search_series
+
+        assert search_series("Le grandi storie") == []
+        assert search_series("Romano Scarpa") == []
+
+    def test_a_spelled_out_qualifier_still_wins(self, inducks_configured):
+        """Relaxing the name must not let the bare title answer for a qualified
+        one: keys are tried most specific first and the first that hits wins."""
+        from models.inducks import search_series
+
+        assert [r["id"] for r in search_series("Topolino (giornale)")] == ["it/TG"]
+
+
 class TestGetIssueMetadata:
 
     def test_maps_the_anthology(self, inducks_configured):

--- a/tests/mocked/test_inducks_provider.py
+++ b/tests/mocked/test_inducks_provider.py
@@ -1,0 +1,398 @@
+"""Tests for the INDUCKS model and provider adapter.
+
+Runs against a real temporary SQLite database rather than mocked cursors: the
+queries here have traps in them (an empty-string date that sorts before every
+real one, a character-name join that multiplies rows) that only real rows catch.
+"""
+import sqlite3
+
+import pytest
+
+from models.providers.base import ProviderType, SearchResult, IssueResult
+from tests.mocked.conftest import build_inducks_sqlite
+
+
+class TestInducksProviderInit:
+
+    def test_provider_attributes(self):
+        from models.providers.inducks_provider import InducksProvider
+
+        p = InducksProvider()
+        assert p.provider_type == ProviderType.INDUCKS
+        assert p.display_name == "INDUCKS (Disney)"
+        assert p.requires_auth is True
+        assert p.auth_fields == ["database_path"]
+
+    def test_registered(self):
+        from models.providers import get_provider_class
+        from models.providers.inducks_provider import InducksProvider
+
+        assert get_provider_class(ProviderType.INDUCKS) is InducksProvider
+
+
+class TestInducksConnection:
+
+    def test_available_when_configured(self, inducks_configured):
+        from models.inducks import check_database_status, is_database_available
+
+        assert is_database_available() is True
+        assert check_database_status()["inducks_available"] is True
+
+    def test_unavailable_when_unconfigured(self, monkeypatch):
+        from models.inducks import check_database_status
+
+        monkeypatch.setattr("models.inducks._get_saved_credentials", lambda: None)
+        monkeypatch.delenv("INDUCKS_DATABASE_PATH", raising=False)
+        status = check_database_status()
+        assert status["inducks_available"] is False
+        assert status["inducks_path_configured"] is False
+
+    def test_env_var_fallback(self, inducks_db_path, monkeypatch):
+        from models.inducks import get_connection_params
+
+        monkeypatch.setattr("models.inducks._get_saved_credentials", lambda: None)
+        monkeypatch.setenv("INDUCKS_DATABASE_PATH", str(inducks_db_path))
+        assert get_connection_params() == {"database_path": str(inducks_db_path)}
+
+    def test_opens_read_only(self, inducks_configured):
+        """The build is 700 MB and shared; a write would also drop -wal files beside it."""
+        from models.inducks import get_connection
+
+        conn = get_connection()
+        assert conn is not None
+        with pytest.raises(sqlite3.OperationalError):
+            conn.execute("CREATE TABLE scribble (x INTEGER)")
+        conn.close()
+
+    def test_successful_connection_test(self, inducks_configured, inducks_creds):
+        from models.providers.inducks_provider import InducksProvider
+
+        assert InducksProvider(credentials=inducks_creds).test_connection() is True
+
+    def test_missing_core_tables(self, tmp_path, monkeypatch):
+        from models.providers.inducks_provider import InducksProvider
+        import models.inducks as inducks_module
+
+        path = str(tmp_path / "broken.db")
+        conn = sqlite3.connect(path)
+        conn.execute("CREATE TABLE inducks_publication (publicationcode TEXT)")
+        conn.commit()
+        conn.close()
+
+        inducks_module.invalidate_inducks_table_cache()
+        monkeypatch.setattr("models.inducks._get_saved_credentials",
+                            lambda: {"database_path": path})
+        try:
+            assert InducksProvider().test_connection() is False
+        finally:
+            inducks_module.invalidate_inducks_table_cache()
+
+
+class TestStartYear:
+    """The derived start year, which the auto-accept gate depends on.
+
+    ``core.bulk_metadata._years_match`` returns False the moment either side is
+    None, so a publication with no year can never auto-accept -- every file
+    lands in the review queue with nothing in the log to explain why.
+    """
+
+    def test_ignores_blank_and_unknown_dates(self, inducks_configured):
+        """it/TL has an empty oldestdate and a 9999 sentinel among its issues.
+
+        A bare MIN(SUBSTR(oldestdate, 1, 4)) returns the empty string here,
+        because '' sorts before every real date. Measured on the real database
+        that mistake blanks the year for 44 of 664 Italian publications instead
+        of 13 -- including Topolino itself.
+        """
+        from models.inducks import search_series
+
+        results = search_series("Topolino (libretto)")
+        assert len(results) == 1
+        assert results[0]["year_began"] == 1949
+
+    def test_naive_min_would_have_failed(self, inducks_db_path):
+        """Pin the trap itself, so nobody 'simplifies' the query back."""
+        conn = sqlite3.connect(inducks_db_path)
+        naive = conn.execute(
+            "SELECT MIN(SUBSTR(oldestdate, 1, 4)) FROM inducks_issue "
+            "WHERE publicationcode = 'it/TL'"
+        ).fetchone()[0]
+        conn.close()
+        assert naive == ""
+
+    def test_no_usable_date_yields_none(self, inducks_configured):
+        """2% of Italian publications genuinely have no date. That is not a bug."""
+        from models.inducks import search_series
+
+        results = search_series("Senza data")
+        assert len(results) == 1
+        assert results[0]["year_began"] is None
+
+    def test_issue_count_is_reported(self, inducks_configured):
+        from models.inducks import search_series
+
+        assert search_series("Topolino (libretto)")[0]["issue_count"] == 4
+
+
+class TestSearchSeries:
+
+    def test_exact_title_wins(self, inducks_configured):
+        from models.inducks import search_series
+
+        results = search_series("Topolino (giornale)")
+        assert [r["id"] for r in results] == ["it/TG"]
+
+    def test_ambiguous_name_returns_every_candidate(self, inducks_configured):
+        """Two publications strip to "Topolino"; guessing between them is how a
+        library ends up confidently mislabelled."""
+        from models.inducks import search_series
+
+        results = search_series("Topolino")
+        assert {r["id"] for r in results} == {"it/TL", "it/TG"}
+
+    def test_country_scoping(self, inducks_configured):
+        """us/WDC exists but is out of scope for an Italian library."""
+        from models.inducks import search_series
+
+        assert search_series("Walt Disney's Comics and Stories") == []
+        assert len(search_series("Walt Disney's Comics and Stories",
+                                 country_codes=["us"])) == 1
+
+    def test_accents_and_punctuation_are_folded(self, inducks_configured):
+        from models.inducks import search_series
+
+        assert [r["id"] for r in search_series("zio  paperone!")] == ["it/ZP"]
+
+    def test_no_match(self, inducks_configured):
+        from models.inducks import search_series
+
+        assert search_series("Nonexistent") == []
+        assert search_series("") == []
+
+    def test_year_orders_candidates(self, inducks_configured):
+        from models.inducks import search_series
+
+        assert search_series("Topolino", 1932)[0]["id"] == "it/TG"
+        assert search_series("Topolino", 1949)[0]["id"] == "it/TL"
+
+    def test_qualifier_kept_when_stripping_would_collide(self, inducks_configured):
+        """Both Topolinos keep their qualifier; Zio Paperone has none to lose."""
+        from models.inducks import search_series
+
+        assert search_series("Topolino (libretto)")[0]["name"] == "Topolino (libretto)"
+        assert search_series("Zio Paperone")[0]["name"] == "Zio Paperone"
+
+
+class TestGetIssueMetadata:
+
+    def test_maps_the_anthology(self, inducks_configured):
+        from models.inducks import get_issue_metadata
+
+        md = get_issue_metadata("it/TL", "1")
+        assert md["Series"] == "Topolino (libretto)"
+        assert md["Number"] == "1"
+        assert md["Title"] == "Il primo numero"
+        assert md["Year"] == 1949
+        assert md["Month"] == 4
+        assert md["Day"] == 7
+        assert md["PageCount"] == "68"
+        assert md["LanguageISO"] == "it"
+        assert md["Web"] == "https://inducks.org/issue.php?c=it/TL++++1"
+
+    def test_summary_is_the_table_of_contents(self, inducks_configured):
+        from models.inducks import get_issue_metadata
+
+        md = get_issue_metadata("it/TL", "1")
+        assert md["Summary"] == (
+            "- Topolino e il cobra bianco\n- Paperino e il ladro di uova"
+        )
+
+    def test_credits_merge_across_stories_in_order(self, inducks_configured):
+        from models.inducks import get_issue_metadata
+
+        md = get_issue_metadata("it/TL", "1")
+        assert md["Writer"] == "Luciano Bottaro, Romano Scarpa"
+        assert md["Penciller"] == "Luciano Bottaro, Giorgio Cavazzano"
+        assert md["Inker"] == "Sandro Zemolin"
+
+    def test_cover_credits_are_excluded(self, inducks_configured):
+        """A cover artist is not the penciller of the book."""
+        from models.inducks import get_issue_metadata
+
+        md = get_issue_metadata("it/TL", "1")
+        assert "Coverist" not in md.get("Penciller", "")
+
+    def test_characters_prefer_the_localised_name(self, inducks_configured):
+        from models.inducks import get_issue_metadata
+
+        md = get_issue_metadata("it/TL", "1")
+        assert md["Characters"] == "Topolino, Paperino"
+
+    def test_most_recent_publisher_wins(self, inducks_configured):
+        """Topolino carries Mondadori then Panini; the modern imprint produced it."""
+        from models.inducks import get_issue_metadata
+
+        assert get_issue_metadata("it/TL", "1")["Publisher"] == "Panini Comics"
+
+    def test_notes_names_the_source(self, inducks_configured):
+        """Notes doubles as the 'already tagged, skip this file' sentinel."""
+        from models.inducks import get_issue_metadata
+
+        assert get_issue_metadata("it/TL", "1")["Notes"].startswith("Metadata from INDUCKS.")
+
+    def test_unknown_date_sentinel_is_not_a_year(self, inducks_configured):
+        """9999-12-31 must not reach ComicInfo, or the date check reads it as a
+        seven-thousand-year conflict and rejects the match."""
+        from models.inducks import get_issue_metadata
+
+        md = get_issue_metadata("it/TL", "3")
+        assert "Year" not in md
+
+    def test_issue_not_found(self, inducks_configured):
+        from models.inducks import get_issue_metadata
+
+        assert get_issue_metadata("it/TL", "9999") is None
+        assert get_issue_metadata("it/TL", "") is None
+        assert get_issue_metadata("", "1") is None
+
+    def test_incomplete_build_is_rejected_not_silently_degraded(self, tmp_path, monkeypatch):
+        """A build missing tables must fail the connection test, loudly.
+
+        INDUCKS ships as one tarball holding the whole database, so a build
+        without ``inducks_story`` is broken rather than merely reduced. Reporting
+        that is more useful than tagging a whole library with no credits in it.
+        """
+        import models.inducks as inducks_module
+        from models.providers.inducks_provider import InducksProvider
+
+        path = build_inducks_sqlite(tmp_path / "core.db", core_only=True)
+        inducks_module.invalidate_inducks_table_cache()
+        monkeypatch.setattr("models.inducks._get_saved_credentials",
+                            lambda: {"database_path": path})
+        monkeypatch.setattr("models.inducks.get_configured_countries", lambda: ["it"])
+        try:
+            assert InducksProvider().test_connection() is False
+        finally:
+            inducks_module.invalidate_inducks_table_cache()
+
+
+class TestComicInfoRoundTrip:
+    """Every mapped field must survive the allowlist in core.comicinfo.
+
+    A key a provider maps but that has no ``add()`` line there is computed and
+    then silently discarded, which is invisible until someone reads the XML.
+    """
+
+    def test_every_field_reaches_the_xml(self, inducks_configured):
+        from core.comicinfo import generate_comicinfo_xml
+        from models.inducks import get_issue_metadata
+
+        md = get_issue_metadata("it/TL", "1")
+        xml = generate_comicinfo_xml(md).decode("utf-8")
+
+        for tag in ("Series", "Number", "Title", "Summary", "Publisher", "Year",
+                    "Month", "Day", "PageCount", "LanguageISO", "Writer",
+                    "Penciller", "Inker", "Characters", "Web", "Notes"):
+            assert f"<{tag}>" in xml, f"{tag} was mapped but never written"
+
+
+class TestProviderAdapter:
+
+    def test_search_series_returns_search_results(self, inducks_configured, inducks_creds):
+        from models.providers.inducks_provider import InducksProvider
+
+        results = InducksProvider(credentials=inducks_creds).search_series("Zio Paperone")
+        assert len(results) == 1
+        assert isinstance(results[0], SearchResult)
+        assert results[0].provider == ProviderType.INDUCKS
+        assert results[0].id == "it/ZP"
+        assert results[0].year == 1987
+
+    def test_get_series(self, inducks_configured, inducks_creds):
+        from models.providers.inducks_provider import InducksProvider
+
+        result = InducksProvider(credentials=inducks_creds).get_series("it/TL")
+        assert result.title == "Topolino (libretto)"
+        assert result.year == 1949
+        assert result.issue_count == 4
+        assert InducksProvider(credentials=inducks_creds).get_series("it/NOPE") is None
+
+    def test_get_issues_sorts_numerically(self, inducks_configured, inducks_creds):
+        """#2 before #3200, not lexicographically."""
+        from models.providers.inducks_provider import InducksProvider
+
+        issues = InducksProvider(credentials=inducks_creds).get_issues("it/TL")
+        assert [i.issue_number for i in issues] == ["1", "2", "3", "3200"]
+
+    def test_get_issue_by_code(self, inducks_configured, inducks_creds):
+        from models.providers.inducks_provider import InducksProvider
+
+        issue = InducksProvider(credentials=inducks_creds).get_issue("it/TL 3200")
+        assert isinstance(issue, IssueResult)
+        assert issue.series_id == "it/TL"
+        assert issue.issue_number == "3200"
+        assert issue.cover_date == "2017-06-27"
+
+    def test_to_comicinfo_uses_full_metadata(self, inducks_configured, inducks_creds):
+        from models.providers.inducks_provider import InducksProvider
+
+        issue = IssueResult(provider=ProviderType.INDUCKS, id="it/TL    1",
+                            series_id="it/TL", issue_number="1")
+        result = InducksProvider(credentials=inducks_creds).to_comicinfo(issue)
+        assert result["Series"] == "Topolino (libretto)"
+        assert result["Writer"] == "Luciano Bottaro, Romano Scarpa"
+
+    def test_to_comicinfo_falls_back(self, inducks_configured, inducks_creds, monkeypatch):
+        from models.providers.inducks_provider import InducksProvider
+
+        monkeypatch.setattr("models.inducks.get_issue_metadata", lambda *a, **k: None)
+        issue = IssueResult(provider=ProviderType.INDUCKS, id="it/TL    1",
+                            series_id="it/TL", issue_number="1",
+                            title="Il primo numero", cover_date="1949-04-07")
+        series = SearchResult(provider=ProviderType.INDUCKS, id="it/TL",
+                              title="Topolino (libretto)", year=1949)
+        result = InducksProvider(credentials=inducks_creds).to_comicinfo(issue, series)
+        assert result["Series"] == "Topolino (libretto)"
+        assert result["Year"] == 1949
+
+    def test_unconfigured_provider_is_inert(self, monkeypatch):
+        """Registration alone must not change behaviour for a library with no
+        INDUCKS database configured."""
+        from models.providers.inducks_provider import InducksProvider
+
+        monkeypatch.setattr("models.inducks._get_saved_credentials", lambda: None)
+        monkeypatch.delenv("INDUCKS_DATABASE_PATH", raising=False)
+        p = InducksProvider()
+        assert p.test_connection() is False
+        assert p.search_series("Topolino") == []
+        assert p.get_series("it/TL") is None
+        assert p.get_issues("it/TL") == []
+        assert p.get_issue_metadata("it/TL", "1") is None
+
+
+class TestDateCheckIntegration:
+    """The issue-level date check from #513, which is what made this provider
+    worth building rather than keeping a separate tagger."""
+
+    def test_classified_as_issue_level(self):
+        from core.metadata_dates import year_is_issue_level
+
+        assert year_is_issue_level("inducks") is True
+        # The batch path passes a display string, matched on lowered substring.
+        assert year_is_issue_level("INDUCKS") is True
+
+    def test_a_wrong_series_is_caught(self, inducks_configured):
+        from core.metadata_dates import date_conflict
+        from models.inducks import get_issue_metadata
+
+        md = get_issue_metadata("it/TL", "3200")
+        # A file claiming 1949 matched against a 2017 issue is a wrong series.
+        assert date_conflict(1949, md["Year"], tolerance=2) is True
+        assert date_conflict(2017, md["Year"], tolerance=2) is False
+
+    def test_country_preference_default(self, monkeypatch):
+        from models.inducks import get_configured_countries
+
+        monkeypatch.setattr("core.database.get_user_preference",
+                            lambda *a, **k: None, raising=False)
+        assert get_configured_countries() == ["us"]

--- a/tests/routes/test_metadata_routes.py
+++ b/tests/routes/test_metadata_routes.py
@@ -948,6 +948,76 @@ class TestSearchMetadataMetronSelection:
         assert resp.get_json()["source"] == "metron"
 
 
+class TestSearchMetadataInducks:
+    """INDUCKS near-misses used to dead-end: try_inducks (batch path) could
+    open the issue picker via note_near_miss, but /api/search-metadata had no
+    inducks branch in either the selected_match dispatch or the
+    non-selection cascade -- picking an issue 404'd, and a library with
+    INDUCKS in its provider order got it silently skipped. See PR #539's
+    review, finding 1.
+    """
+
+    def test_selection_followup_returns_metadata_not_404(self, app, client):
+        from contextlib import ExitStack
+        with ExitStack() as stack:
+            stack.enter_context(patch("routes.metadata.add_comicinfo_to_cbz", return_value=True))
+            stack.enter_context(patch("core.database.set_has_comicinfo"))
+            stack.enter_context(patch(
+                "models.inducks.get_issue_metadata",
+                return_value={"Series": "Topolino (libretto)", "Number": "3200"},
+            ))
+
+            resp = client.post('/api/search-metadata', json={
+                'file_path': '/data/Topolino 3200.cbz',
+                'file_name': 'Topolino 3200.cbz',
+                'selected_match': {
+                    'provider': 'inducks', 'series_id': 'it/TL', 'issue_number': '3200',
+                },
+            })
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["source"] == "inducks"
+        assert data["metadata"]["Series"] == "Topolino (libretto)"
+
+    def test_non_selection_cascade_reaches_inducks(self, app, client):
+        """A Disney-shaped filename with INDUCKS in the library's provider
+        order must reach models.inducks.get_issue_metadata rather than being
+        silently skipped -- the single-file cascade had no inducks branch
+        at all before this fix."""
+        from contextlib import ExitStack
+        with ExitStack() as stack:
+            stack.enter_context(patch("core.database.get_library_providers", return_value=[
+                {"provider_type": "inducks", "enabled": True},
+            ]))
+            stack.enter_context(patch("models.inducks.check_database_status",
+                                      return_value={"inducks_available": True}))
+            stack.enter_context(patch("models.inducks.search_series", return_value=[
+                {"id": "it/TL", "name": "Topolino (libretto)"},
+            ]))
+            stack.enter_context(patch("models.inducks.narrow_to_issue", return_value=[
+                {"id": "it/TL", "name": "Topolino (libretto)"},
+            ]))
+            get_issue_metadata = MagicMock(
+                return_value={"Series": "Topolino (libretto)", "Number": "3200"})
+            stack.enter_context(patch("models.inducks.get_issue_metadata", get_issue_metadata))
+            stack.enter_context(patch("routes.metadata.add_comicinfo_to_cbz", return_value=True))
+            stack.enter_context(patch("core.database.update_file_index_from_comicinfo"))
+
+            resp = client.post('/api/search-metadata', json={
+                'file_path': '/data/Topolino 3200.cbz',
+                'file_name': 'Topolino 3200.cbz',
+                'library_id': 1,
+            })
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert data["source"] == "inducks"
+        get_issue_metadata.assert_called_once_with("it/TL", "3200")
+
+
 class TestBatchMetadataSkipProviders:
     """The folder/batch flow (/api/batch-metadata) must expose provider_order on
     its ComicVine selection and honor skip_providers so the user can fall through

--- a/tests/routes/test_search_metadata_provider_coverage.py
+++ b/tests/routes/test_search_metadata_provider_coverage.py
@@ -1,0 +1,136 @@
+"""Structural guard: every provider that can produce a near-miss must also
+have a selected_match dispatch branch in /api/search-metadata.
+
+The bug this guards against (PR #539's review, finding 1): try_inducks (the
+batch path) could put a file into result['unmatched'] with can_select_issue
+True via note_near_miss('inducks', ...), which opens the issue-picker modal
+(CLU.resolveUnmatchedIssues). But the selected_match dispatch in
+/api/search-metadata had no 'inducks' branch, so picking an issue always
+404'd -- the picker opened but could never apply. The single-file cascade's
+own near-miss recorder (_record_near_miss) has the identical shape and the
+identical failure mode.
+
+Parsed via ast rather than imported: this asserts a structural property of
+the source (every provider name that reaches note_near_miss / _record_near_miss
+is also a literal compared against `provider` in the selection dispatch), not
+runtime behaviour, so it stays meaningful even if the module can't be
+imported in some environment. Mirrors the AST-assertion style used for app.py
+elsewhere in this suite (e.g. tests/unit/test_wanted_digest_hook.py).
+"""
+import ast
+import os
+
+import pytest
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+METADATA_PATH = os.path.join(PROJECT_ROOT, "routes", "metadata.py")
+
+
+@pytest.fixture(scope="module")
+def tree():
+    with open(METADATA_PATH, encoding="utf-8") as fh:
+        return ast.parse(fh.read())
+
+
+def _string_literals(node):
+    """String constants directly inside a tuple/list/set literal, or the
+    literal itself if it already is one."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return [node.value]
+    if isinstance(node, (ast.Tuple, ast.List, ast.Set)):
+        return [e.value for e in node.elts
+                if isinstance(e, ast.Constant) and isinstance(e.value, str)]
+    return []
+
+
+def _near_miss_providers(tree):
+    """Provider slugs passed to note_near_miss(...) or
+    _record_near_miss(near_misses, ...) anywhere in the module."""
+    providers = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name):
+            continue
+        name = node.func.id
+        if name == "note_near_miss" and node.args:
+            providers.update(_string_literals(node.args[0]))
+        elif name == "_record_near_miss" and len(node.args) >= 2:
+            providers.update(_string_literals(node.args[1]))
+    return providers
+
+
+def _provider_literals_from_test(test):
+    """String literals compared against a bare `provider` name in
+    `provider == 'x'` or `provider in ('x', 'y')`."""
+    if not isinstance(test, ast.Compare):
+        return []
+    if not (isinstance(test.left, ast.Name) and test.left.id == "provider"):
+        return []
+    literals = []
+    for op, comparator in zip(test.ops, test.comparators):
+        if isinstance(op, ast.Eq):
+            literals.extend(_string_literals(comparator))
+        elif isinstance(op, ast.In):
+            literals.extend(_string_literals(comparator))
+    return literals
+
+
+def _selection_dispatch_providers(tree):
+    """Providers handled in /api/search-metadata's `if selected_match:`
+    if/elif chain (the dispatch that runs after the user picks from the
+    selection or issue-picker modal)."""
+    func = next(
+        (n for n in ast.walk(tree)
+         if isinstance(n, ast.FunctionDef) and n.name == "search_metadata"),
+        None,
+    )
+    assert func is not None, "search_metadata not found in routes/metadata.py"
+
+    selected_if = next(
+        (n for n in ast.walk(func)
+         if isinstance(n, ast.If) and isinstance(n.test, ast.Name)
+         and n.test.id == "selected_match"),
+        None,
+    )
+    assert selected_if is not None, "`if selected_match:` block not found"
+
+    chain_start = next(
+        (stmt for stmt in selected_if.body
+         if isinstance(stmt, ast.If) and _provider_literals_from_test(stmt.test)),
+        None,
+    )
+    assert chain_start is not None, "provider dispatch if/elif chain not found"
+
+    providers = []
+    node = chain_start
+    while node is not None:
+        providers.extend(_provider_literals_from_test(node.test))
+        if len(node.orelse) == 1 and isinstance(node.orelse[0], ast.If):
+            node = node.orelse[0]
+        else:
+            node = None
+    return set(providers)
+
+
+class TestSelectionDispatchCoversEveryNearMissProvider:
+
+    def test_extraction_actually_finds_the_known_providers(self, tree):
+        """Pin the extraction itself, so a refactor of either shape can't
+        silently make the real assertion below vacuous."""
+        near_miss = _near_miss_providers(tree)
+        assert {"metron", "comicvine", "comicvine_sqlite", "gcd", "gcd_api",
+                "inducks"} <= near_miss
+
+        dispatched = _selection_dispatch_providers(tree)
+        assert {"metron", "comicvine", "comicvine_sqlite", "gcd", "gcd_api",
+                "inducks"} <= dispatched
+
+    def test_every_near_miss_provider_has_a_dispatch_branch(self, tree):
+        near_miss = _near_miss_providers(tree)
+        dispatched = _selection_dispatch_providers(tree)
+        missing = near_miss - dispatched
+        assert not missing, (
+            f"{sorted(missing)} can produce a near-miss / issue-picker "
+            f"(note_near_miss or _record_near_miss) but has no "
+            f"`selected_match` dispatch branch in /api/search-metadata -- "
+            f"picking an issue for it will 404. See PR #539's review."
+        )

--- a/tests/unit/test_metadata_dates.py
+++ b/tests/unit/test_metadata_dates.py
@@ -91,6 +91,28 @@ class TestIssueYearFromFilename:
     def test_same_year_twice_is_still_one_claim(self):
         assert issue_year_from_filename("Batman (1940) 001 1940.cbz") == 1940
 
+    def test_issue_number_exemption(self):
+        """Topolino issue numbers run past #3600, so 'Topolino 2000.cbz' is
+        both a plausible year and the issue number -- only the caller, which
+        parsed the issue number separately, can tell them apart."""
+        assert issue_year_from_filename("Topolino 2000.cbz", issue_number="2000") is None
+        assert issue_year_from_filename("Topolino 2000.cbz", issue_number=2000) is None
+
+    def test_issue_number_exemption_does_not_apply_to_a_different_number(self):
+        assert issue_year_from_filename("Topolino 2000.cbz", issue_number="1") == 2000
+
+    def test_issue_number_none_or_unparseable_is_a_no_op(self):
+        assert issue_year_from_filename("Batman 001 (1940).cbz", issue_number=None) == 1940
+        assert issue_year_from_filename("Batman 001 (1940).cbz", issue_number="not a number") == 1940
+
+    def test_two_year_case_still_short_circuits_regardless_of_issue_number(self):
+        """Regression guard: a filename carrying both the issue number and a
+        real year is already ambiguous on its own -- two distinct candidates --
+        and must stay unresolved rather than being narrowed to the real year
+        by the exemption."""
+        assert issue_year_from_filename(
+            "Topolino 1975 (1993).cbz", issue_number="1975") is None
+
 
 class TestDateConflict:
 
@@ -146,6 +168,22 @@ class TestEvaluate:
     def test_no_year_in_filename_is_not_a_conflict(self, mode):
         mode(MODE_ENFORCE)
         assert evaluate("Diabolik 001.cbz", "1999") == (MODE_ENFORCE, False, None)
+
+    def test_issue_number_exemption_passes_through(self, mode):
+        """A filename year that equals the issue number (e.g. Topolino 2000)
+        must not be enforced as a date conflict against the real issue date."""
+        mode(MODE_ENFORCE)
+        assert evaluate("Topolino 2000.cbz", "1993", issue_number="2000") == (
+            MODE_ENFORCE, False, None
+        )
+
+    def test_issue_number_exemption_does_not_hide_a_real_conflict(self, mode):
+        """The exemption only fires when the filename year IS the issue
+        number; an unrelated issue number changes nothing."""
+        mode(MODE_ENFORCE)
+        assert evaluate("Topolino 2000.cbz", "1993", issue_number="1") == (
+            MODE_ENFORCE, True, 2000
+        )
 
 
 class TestSettings:


### PR DESCRIPTION
## 📝 Description
Closes #538

Adds INDUCKS as a metadata provider, for Disney comics. It follows the shape `gcd` and
`comicvine_sqlite` established: the user builds a SQLite database, gives CLU the path, and CLU
reads it read-only. No new dependencies, no schema migration, and nothing changes for a library
with no database configured.

INDUCKS is the reference index for this material — 84 countries, 7,310 publications, 259,785
issues — and it is where the other providers cannot help. A Disney issue is an anthology of a
dozen unrelated stories, so GCD models as one book what INDUCKS models properly, and the
story-level credits and contents simply are not there to be read. By issues indexed the largest
countries are Sweden, Italy and the Netherlands, with the US ninth, so this is mostly about the
part of a library that currently cannot be tagged at all.

The issue puts four decisions to you and I have implemented what I said I would there. Each is a
small change if you would rather otherwise, and I have kept them isolated for that reason:

1. **The database is the user's to build.** Exactly like GCD — CLU never downloads or builds
   anything. `docs/inducks-provider.md` says where it comes from.
2. **Country scoping defaults to `us`.** An `inducks_countries` preference read through
   `/api/preferences/<key>`, mirroring `gcd_metadata_languages`. The default keeps a freshly
   configured provider harmless rather than confidently foreign; it is a one-line change.
3. **The album is the ComicInfo unit.** `Series` and `Number` name the album, `Summary` is its
   table of contents, credits and characters merge across the stories in first-appearance order
   with covers excluded. It is a real modelling choice and it is visible to users.
4. **Registered after the existing providers**, so it displaces nothing.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary — nothing to update: no new dependencies, and the
      database path is a provider credential like GCD's
- [x] Verified build locally (`docker build -t dev .`)

`models/inducks.py` holds the queries and `models/providers/inducks_provider.py` the adapter,
mirroring `models/gcd.py` + `gcd_provider.py`. Alongside that: one `ProviderType` member, a
`try_inducks` in the batch dispatch, the provider card and audit-filter entries, and
`docs/inducks-provider.md`.

Three things are worth calling out because they are not obvious from the diff.

**The start year is derived, and the obvious query is wrong.** `inducks_publication` has no
start-year column, and `MIN(SUBSTR(oldestdate, 1, 4))` fails twice over: `oldestdate` is often the
empty string, which sorts before every real date, and INDUCKS writes `9999-12-31` for an unknown
one. Over the 664 Italian publications that have issues, the naive form leaves 44 of them with no
year against 13 for the corrected one — including `it/TL`, *Topolino* itself, whose real start
year is 1949. It matters because `_years_match` refuses to auto-accept a series whose year is
`None`, so those publications would have gone to the review queue on every file forever, with
nothing in the log to say why.

**Matching needs the issue number, not just the title.** A Disney title names several runs at
once — eleven Italian publications reduce to the name "Topolino" — so the title can never identify
one. But these folders are named after a slice of a run rather than after the publication
("Topolino anno 1975", "Anno 1986 vol 1571-1622"), so the name frequently does not contain the
title at all. So the name is read loosely (folder name, folder name minus a trailing run marker,
then the series name `extract_comic_values` parses from the filename — CLU's own parser, not a
second one) and the candidates are then narrowed strictly: the publication must actually hold that
issue number, then that issue's date must agree with any year the filename states, then an exact
title beats a qualifier-stripped one. Of the eleven publications called "Topolino", only `it/TL`
has an issue 1500 at all, so the loose name is safe. More than one survivor is refused and the
folder goes to review rather than being guessed at.

**It inherits the date check from #513.** `inducks` joins `_ISSUE_YEAR_PROVIDERS`, since
`inducks_issue.oldestdate` refined by `inducks_issuedate` is a real per-issue date. A rejected
match falls through to the next provider as usual.

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass — `4,663 passed`, of which 56 are new

Beyond the unit tests, three checks against the real 728 MB database:

**Run over a whole library.** 5,369 archives, 183 folders, scoped to `it`. 3,018 files tagged;
every folder that tagged is genuinely Disney material, with nothing touched in the Bonelli, RCS or
Marvel parts of the library. Five matches disagree with a year stated in the filename by more than
two years, each a scan-tag discrepancy rather than a wrong series. 80 seconds end to end,
including building every ComicInfo dict — about 15 ms per file.

**The derived start year is right.** Of the folders resolving to one publication, four carry a
year in their name and all four agree exactly with the year derived from the issues.

**Nothing was lost in the port.** This began as a standalone tool that has been tagging a real
library for a while. 2,837 issues across all 664 Italian publications were tagged by both and
compared field by field: neither found an issue the other missed, and the only differences were 18
`Characters` values from *Disney lingua latina*, where the old tool hardcoded Italian names and
the provider correctly uses the publication's own language.

## 📸 Screenshots / Logs
A folder named after a year rather than a publication, tagged in the dev container — the run
marker is stripped, the eleven "Topolino" publications are narrowed to `it/TL` by the issue
number, and the issue's own date wins over the folder's:

```
/data/Topolino anno 2017/Topolino 3200.cbz
```
```xml
<ComicInfo>
  <Series>Topolino (libretto)</Series>
  <Number>3200</Number>
  <Summary>- Che aria tira a... Topolinia
- Paperino &amp; il dollaro fatale
- Topolino e le artinuvole
  ...</Summary>
  <Year>2017</Year>
  <Month>3</Month>
  <Day>22</Day>
  <Publisher>Panini Comics</Publisher>
  <Characters>Topolino, Minni, Paperino, Qui Quo Qua, Zio Paperone, ...</Characters>
  <LanguageISO>it</LanguageISO>
  <PageCount>164</PageCount>
  <Web>https://inducks.org/issue.php?c=it/TL+3200</Web>
  <Notes>Metadata from INDUCKS. Issue: it/TL 3200 — retrieved 2026-09-01.</Notes>
</ComicInfo>
```

Two notes rather than logs:

`CONTRIBUTING.md` asks for a `CHANGELOG.md` entry and there is no `CHANGELOG.md` in the repository,
so I have not created one unasked — happy to add both if you would like it started.

Separately, and not part of this PR: `issue_year_from_filename` reads any standalone four-digit
number as a publication year, so `Topolino 1904.cbz` claims 1904 and the date check compares it
against the issue's real 1992. Under `enforce` that rejects a correct match. It affects every
provider, not just this one — any series whose issue numbers reach four digits — and 49 files in
the library above trip it. I will open it separately.
