### PR TITLE
fix: do not read a four-digit issue number as a publication year

### DIFF
--- a/core/bulk_metadata.py
+++ b/core/bulk_metadata.py
@@ -491,7 +491,8 @@ def _date_conflicted(file_path: str, issue: IssueResult) -> bool:
         # would silently turn every volume into a conflict.
         return False
     mode, conflicted, _ = evaluate_issue_date(
-        os.path.basename(file_path), issue.cover_date or issue.store_date
+        os.path.basename(file_path), issue.cover_date or issue.store_date,
+        issue.issue_number,
     )
     return conflicted and mode == MODE_ENFORCE
 

--- a/core/bulk_metadata.py
+++ b/core/bulk_metadata.py
@@ -477,11 +477,21 @@ def _resolve_issue(
     return None, issues
 
 
-def _date_conflicted(file_path: str, issue: IssueResult) -> bool:
+def _date_conflicted(file_path: str, issue: IssueResult, issue_text: str) -> bool:
     """True when the check is enforcing and this issue's date contradicts the file.
 
     Under 'log' the conflict is recorded by ``evaluate_issue_date`` and the write
     proceeds unchanged, so only 'enforce' diverts the match to review.
+
+    ``issue_text`` must be the number ``extract_issue_number`` read from
+    *this file's* name, not ``issue.issue_number`` (the provider's own,
+    normalised form of the same number). The safety argument for discarding a
+    year that matches the issue number rests on that number being one the
+    caller already committed to reading out of the filename -- passing the
+    provider's copy is only equivalent here because both callers select
+    ``issue`` via ``issues_by_norm``, keyed on the filename's normalised
+    number, and that coupling is invisible at this call site. Passing
+    ``issue_text`` directly says what the check actually means.
     """
     provider = getattr(issue.provider, "value", issue.provider)
     if not year_is_issue_level(provider):
@@ -492,7 +502,7 @@ def _date_conflicted(file_path: str, issue: IssueResult) -> bool:
         return False
     mode, conflicted, _ = evaluate_issue_date(
         os.path.basename(file_path), issue.cover_date or issue.store_date,
-        issue.issue_number,
+        issue_text,
     )
     return conflicted and mode == MODE_ENFORCE
 
@@ -769,7 +779,7 @@ def _process_folder(
 
         norm = issue_text.lstrip('0') or '0'
         matches = issues_by_norm.get(norm, [])
-        if len(matches) == 1 and _date_conflicted(file_path, matches[0]):
+        if len(matches) == 1 and _date_conflicted(file_path, matches[0], issue_text):
             add_review_item(
                 job_id=job_id,
                 folder_path=folder_path,
@@ -931,7 +941,7 @@ def _process_oneshot_folder(
 
         norm = issue_text.lstrip('0') or '0'
         matches = issues_by_norm.get(norm, [])
-        if len(matches) == 1 and _date_conflicted(file_path, matches[0]):
+        if len(matches) == 1 and _date_conflicted(file_path, matches[0], issue_text):
             add_review_item(
                 job_id=job_id,
                 folder_path=folder_path,

--- a/core/metadata_dates.py
+++ b/core/metadata_dates.py
@@ -135,7 +135,24 @@ def date_check_tolerance() -> int:
     return value if value >= 0 else DEFAULT_TOLERANCE_YEARS
 
 
-def issue_year_from_filename(name: Optional[str]) -> Optional[int]:
+def _is_the_issue_number(year: int, issue_number: Any) -> bool:
+    """Whether the year we just parsed is really the issue number over again.
+
+    Compared as integers so that "1904", "01904" and 1904 all count. A number
+    carrying any suffix -- "1904A", "1904.1" -- is not a bare four-digit run of
+    digits and never produced a year in the first place, since ``_YEAR``
+    requires a non-alphanumeric on both sides.
+    """
+    if issue_number is None:
+        return False
+    text = str(issue_number).strip()
+    if not text.isdigit():
+        return False
+    return int(text) == year
+
+
+def issue_year_from_filename(name: Optional[str],
+                             issue_number: Any = None) -> Optional[int]:
     """The publication year a filename claims, or None if it claims none.
 
     Distinct from ``extract_year_from_name`` in ``routes/metadata.py``, which
@@ -151,6 +168,23 @@ def issue_year_from_filename(name: Optional[str]) -> Optional[int]:
     Returns None when the filename names more than one distinct year: two
     candidates cannot disambiguate anything, and guessing between them is how a
     correct match gets rejected.
+
+    A candidate that is simply the issue number over again is discarded, which
+    is why ``issue_number`` is worth passing wherever the caller has it.
+    "Topolino 1904.cbz" is issue #1904 of a run that reached #3,600, and there
+    is nothing in the string to tell those digits from the year in "Batman 001
+    (2016).cbz" -- a space before and a dot after, in both. The only thing that
+    distinguishes them is that they have already been read as the issue number.
+    Long-running series really do get there: Topolino, Diabolik and Tex all
+    number past 1900, and every issue of theirs in that range would otherwise be
+    compared against a "year" decades off its real date and rejected as a bad
+    match.
+
+    Discarded before the count rather than after it, which matters in both
+    directions. "Topolino 1904.cbz" drops to no candidate and the check
+    abstains. "Topolino 1904 (1992).cbz" drops from two candidates to one, so a
+    file the check used to skip as ambiguous is now checked against the year it
+    actually states.
     """
     if not name:
         return None
@@ -159,7 +193,9 @@ def issue_year_from_filename(name: Optional[str]) -> Optional[int]:
     years = {
         int(match.group(0)) for match in _YEAR.finditer(str(name))
     }
-    plausible = {year for year in years if 1900 <= year <= upper_bound}
+    plausible = {year for year in years
+                 if 1900 <= year <= upper_bound
+                 and not _is_the_issue_number(year, issue_number)}
 
     if len(plausible) != 1:
         return None
@@ -209,17 +245,22 @@ def conflict_message(filename: str, filename_year: int, issue_date: Any) -> str:
     )
 
 
-def evaluate(filename: Optional[str], issue_date: Any) -> tuple:
+def evaluate(filename: Optional[str], issue_date: Any,
+             issue_number: Any = None) -> tuple:
     """Convenience for call sites: ``(mode, conflicted, filename_year)``.
 
     Short-circuits entirely when the mode is 'off', so the disabled path costs
     one config read and does no parsing at all.
+
+    Pass ``issue_number`` wherever it is known: it is what stops a four-digit
+    issue number being read as the year and rejecting a correct match. See
+    ``issue_year_from_filename``.
     """
     mode = date_check_mode()
     if mode == MODE_OFF:
         return MODE_OFF, False, None
 
-    filename_year = issue_year_from_filename(filename)
+    filename_year = issue_year_from_filename(filename, issue_number)
     conflicted = date_conflict(filename_year, issue_date)
     if conflicted:
         app_logger.info(conflict_message(filename, filename_year, issue_date))

--- a/core/metadata_dates.py
+++ b/core/metadata_dates.py
@@ -135,20 +135,30 @@ def date_check_tolerance() -> int:
     return value if value >= 0 else DEFAULT_TOLERANCE_YEARS
 
 
+_LEADING_DIGITS = re.compile(r"^(\d+)")
+
+
 def _is_the_issue_number(year: int, issue_number: Any) -> bool:
     """Whether the year we just parsed is really the issue number over again.
 
-    Compared as integers so that "1904", "01904" and 1904 all count. A number
-    carrying any suffix -- "1904A", "1904.1" -- is not a bare four-digit run of
-    digits and never produced a year in the first place, since ``_YEAR``
-    requires a non-alphanumeric on both sides.
+    Compared against the *leading integer run* of ``issue_number``, not the
+    whole string, so a decimal or lettered point issue still matches: "1904.1"
+    and "1904.MU" are issue #1904 same as "1904" is, and ``_YEAR`` matches
+    "1904" inside "Topolino 1904.1.cbz" just as happily as it matches
+    "Topolino 1904.cbz" -- "." is non-alphanumeric, so the lookbehind/lookahead
+    in ``_YEAR`` do not exclude it. Requiring ``str.isdigit()`` on the whole
+    string missed exactly this case, and separately raised on digit characters
+    outside ASCII 0-9 that ``isdigit()`` accepts but ``int()`` rejects (e.g.
+    the superscript '²' or circled '①') -- a regex match on digit
+    characters (``\\d``) cannot, so this never raises.
     """
     if issue_number is None:
         return False
     text = str(issue_number).strip()
-    if not text.isdigit():
+    match = _LEADING_DIGITS.match(text)
+    if not match:
         return False
-    return int(text) == year
+    return int(match.group(1)) == year
 
 
 def issue_year_from_filename(name: Optional[str],
@@ -169,8 +179,8 @@ def issue_year_from_filename(name: Optional[str],
     candidates cannot disambiguate anything, and guessing between them is how a
     correct match gets rejected.
 
-    A candidate that is simply the issue number over again is discarded, which
-    is why ``issue_number`` is worth passing wherever the caller has it.
+    A sole candidate that is simply the issue number over again is discarded,
+    which is why ``issue_number`` is worth passing wherever the caller has it.
     "Topolino 1904.cbz" is issue #1904 of a run that reached #3,600, and there
     is nothing in the string to tell those digits from the year in "Batman 001
     (2016).cbz" -- a space before and a dot after, in both. The only thing that
@@ -180,11 +190,20 @@ def issue_year_from_filename(name: Optional[str],
     compared against a "year" decades off its real date and rejected as a bad
     match.
 
-    Discarded before the count rather than after it, which matters in both
-    directions. "Topolino 1904.cbz" drops to no candidate and the check
-    abstains. "Topolino 1904 (1992).cbz" drops from two candidates to one, so a
-    file the check used to skip as ambiguous is now checked against the year it
-    actually states.
+    The discard happens strictly AFTER the "exactly one candidate" count, never
+    before it. Filtering the issue number out first would turn a filename that
+    names *two* years -- one of them the issue number, one of them a second
+    year the filename happens to carry for some other reason -- into a
+    single, "confident" candidate. Italian scene releases routinely append a
+    second year that is a scan or reprint date, not the publication date:
+    "Topolino 1904 (c2c) (2008).cbz" is issue #1904 (published 1992), scanned
+    in 2008, and if that promotion were allowed the check would compare the
+    real issue against 2008 and reject a correct match -- the exact failure
+    mode this function exists to prevent, just relocated. Counting first means
+    the discard can only ever turn a *single* confident-but-wrong candidate
+    into abstention; it can never manufacture a false conflict, because a
+    filename with two years abstains regardless of which one matches the issue
+    number.
     """
     if not name:
         return None
@@ -193,13 +212,13 @@ def issue_year_from_filename(name: Optional[str],
     years = {
         int(match.group(0)) for match in _YEAR.finditer(str(name))
     }
-    plausible = {year for year in years
-                 if 1900 <= year <= upper_bound
-                 and not _is_the_issue_number(year, issue_number)}
+    plausible = {year for year in years if 1900 <= year <= upper_bound}
 
     if len(plausible) != 1:
         return None
-    return plausible.pop()
+
+    year = plausible.pop()
+    return None if _is_the_issue_number(year, issue_number) else year
 
 
 def _year_of(issue_date: Any) -> Optional[int]:

--- a/routes/metadata.py
+++ b/routes/metadata.py
@@ -1774,7 +1774,7 @@ def batch_metadata():
                         if not try_fn():
                             return False
                         _mode, _conflict, _year = evaluate_issue_date(
-                            filename, _issue_date_of(metadata, source)
+                            filename, _issue_date_of(metadata, source), issue_number
                         )
                         if _conflict and _mode == DATE_MODE_ENFORCE:
                             app_logger.info(
@@ -4385,7 +4385,7 @@ def search_metadata():
                 # filename. The selection follow-up above is exempt — there the
                 # user picked the series themselves.
                 _dc_mode, _dc_conflict, _dc_year = evaluate_issue_date(
-                    file_name, _issue_date_of(metadata, provider_type)
+                    file_name, _issue_date_of(metadata, provider_type), issue_number
                 )
                 if _dc_conflict and _dc_mode == DATE_MODE_ENFORCE:
                     app_logger.info(

--- a/tests/routes/test_metadata_routes.py
+++ b/tests/routes/test_metadata_routes.py
@@ -1885,6 +1885,32 @@ class TestDateCheckFallthrough:
         single = inspect.getsource(metadata_module.search_metadata)
         assert "_issue_date_of(metadata, provider_type)" in single
 
+    def test_both_paths_pass_the_issue_number_to_the_date_check(self):
+        """A four-digit issue number ('Topolino 1904.cbz') looks exactly like a
+        year, and `evaluate` only tells the two apart when handed the issue
+        number it was matched against (core/metadata_dates.py).
+
+        app.py cannot be imported in tests, and neither call site is otherwise
+        exercised directly, so this pins the wiring the same way
+        `test_both_paths_pass_the_provider_to_the_date_extractor` pins the
+        provider argument -- a refactor that drops the third argument would
+        pass the full suite silently and reintroduce #540.
+        """
+        import inspect
+        from routes import metadata as metadata_module
+
+        batch = inspect.getsource(metadata_module.batch_metadata)
+        assert re.search(
+            r"evaluate_issue_date\(\s*filename,\s*_issue_date_of\(metadata, source\),\s*issue_number\s*\)",
+            batch,
+        ), "accept_match must pass issue_number to evaluate_issue_date"
+
+        single = inspect.getsource(metadata_module.search_metadata)
+        assert re.search(
+            r"evaluate_issue_date\(\s*file_name,\s*_issue_date_of\(metadata, provider_type\),\s*issue_number\s*\)",
+            single,
+        ), "the automatic-match date check must pass issue_number to evaluate_issue_date"
+
 
 class TestBackfillCredits:
     """Manual trigger for the Metron credit backfill sweep.

--- a/tests/unit/test_bulk_metadata_date_check.py
+++ b/tests/unit/test_bulk_metadata_date_check.py
@@ -16,12 +16,13 @@ from models.providers import ProviderType
 from models.providers.base import IssueResult, SearchResult
 
 
-def _issue(cover_date=None, store_date=None, provider=ProviderType.GCD):
+def _issue(cover_date=None, store_date=None, provider=ProviderType.GCD,
+           issue_number='1'):
     return IssueResult(
         provider=provider,
         id='500',
         series_id='200',
-        issue_number='1',
+        issue_number=issue_number,
         title='The Beginning',
         cover_date=cover_date,
         store_date=store_date,
@@ -45,38 +46,59 @@ class TestDateConflicted:
 
     def test_off_never_diverts(self, mode):
         mode(MODE_OFF)
-        assert _date_conflicted(CONFLICTING, _issue(cover_date='1999-06-01')) is False
+        assert _date_conflicted(CONFLICTING, _issue(cover_date='1999-06-01'), '1') is False
 
     def test_log_reports_but_does_not_divert(self, mode):
         """'log' must write exactly what 'off' writes."""
         mode(MODE_LOG)
-        assert _date_conflicted(CONFLICTING, _issue(cover_date='1999-06-01')) is False
+        assert _date_conflicted(CONFLICTING, _issue(cover_date='1999-06-01'), '1') is False
 
     def test_enforce_diverts_a_conflicting_match(self, mode):
         mode(MODE_ENFORCE)
-        assert _date_conflicted(CONFLICTING, _issue(cover_date='1999-06-01')) is True
+        assert _date_conflicted(CONFLICTING, _issue(cover_date='1999-06-01'), '1') is True
 
     def test_enforce_allows_an_agreeing_match(self, mode):
         mode(MODE_ENFORCE)
-        assert _date_conflicted(CONFLICTING, _issue(cover_date='2014-01-01')) is False
+        assert _date_conflicted(CONFLICTING, _issue(cover_date='2014-01-01'), '1') is False
 
     def test_falls_back_to_store_date(self, mode):
         mode(MODE_ENFORCE)
-        assert _date_conflicted(CONFLICTING, _issue(store_date='1999-06-01')) is True
+        assert _date_conflicted(CONFLICTING, _issue(store_date='1999-06-01'), '1') is True
 
     def test_issue_without_any_date_is_allowed(self, mode):
         """A provider that carries no dates must not have every match rejected."""
         mode(MODE_ENFORCE)
-        assert _date_conflicted(CONFLICTING, _issue()) is False
+        assert _date_conflicted(CONFLICTING, _issue(), '1') is False
 
     def test_filename_without_a_year_is_allowed(self, mode):
         mode(MODE_ENFORCE)
         assert _date_conflicted('/comics/Diabolik 001.cbz',
-                                _issue(cover_date='1999-06-01')) is False
+                                _issue(cover_date='1999-06-01'), '1') is False
 
     def test_tolerance_is_respected(self, mode):
         mode(MODE_ENFORCE, tolerance=20)
-        assert _date_conflicted(CONFLICTING, _issue(cover_date='1999-06-01')) is False
+        assert _date_conflicted(CONFLICTING, _issue(cover_date='1999-06-01'), '1') is False
+
+    def test_uses_the_filename_issue_number_not_the_providers(self, mode):
+        """The safety argument for discarding a year that matches the issue
+        number rests on that number being one the caller read from the
+        filename. The provider's own `issue.issue_number` is only usually
+        equal to it (both callers select `issue` via `issues_by_norm`, keyed
+        on the filename's number) -- passing it directly instead would say
+        the wrong thing even where the values happen to agree.
+
+        Here they deliberately disagree: the provider's record is issue '1',
+        but the caller matched it against the filename's issue number, which
+        is what "Topolino 1904.cbz" actually reads as. Passing that number
+        discards the filename's only year candidate and the check abstains.
+        """
+        mode(MODE_ENFORCE)
+        issue = _issue(cover_date='1992-05-24', issue_number='1')
+        assert _date_conflicted('/comics/Topolino 1904.cbz', issue, '1904') is False
+        # The provider's issue_number alone ('1') does not collide with the
+        # filename's year, so if the call site regressed to passing
+        # issue.issue_number this would report a conflict instead.
+        assert _date_conflicted('/comics/Topolino 1904.cbz', issue, '1') is True
 
 
 class TestProviderExemption:
@@ -88,12 +110,12 @@ class TestProviderExemption:
         series would otherwise become a conflict."""
         mode(MODE_ENFORCE)
         issue = _issue(cover_date='1989-01-01', provider=ProviderType.MANGADEX)
-        assert _date_conflicted(CONFLICTING, issue) is False
+        assert _date_conflicted(CONFLICTING, issue, '1') is False
 
     def test_comic_provider_is_still_checked(self, mode):
         mode(MODE_ENFORCE)
         issue = _issue(cover_date='1999-06-01', provider=ProviderType.COMICVINE)
-        assert _date_conflicted(CONFLICTING, issue) is True
+        assert _date_conflicted(CONFLICTING, issue, '1') is True
 
 
 def _series(year, title='Diabolik', provider=ProviderType.GCD):

--- a/tests/unit/test_metadata_dates.py
+++ b/tests/unit/test_metadata_dates.py
@@ -125,16 +125,39 @@ class TestIssueNumberReadAsAYear:
     def test_a_real_year_is_untouched(self, name, number, expected):
         assert issue_year_from_filename(name, number) == expected
 
-    def test_it_also_rescues_a_file_the_check_used_to_skip(self):
-        """Discarding the number before counting candidates, not after.
+    def test_a_second_candidate_stays_ambiguous_even_once_the_issue_number_is_known(self):
+        """The discard happens AFTER the "exactly one candidate" count, not
+        before it -- so a filename naming two years stays ambiguous, whether or
+        not one of them is the issue number.
 
-        "Topolino 1904 (1992).cbz" names two plausible years, so the check used
-        to abstain as ambiguous. One of them is the issue number, so once it is
-        dropped the remaining candidate is the year the file actually states and
-        the check can do its job.
+        Discarding first would instead *promote* "Topolino 1904 (1992).cbz"
+        from two candidates to a single "confident" one once told the issue
+        number is 1904, and report 1992 as the publication year. That looks
+        like a rescue for this exact file, but the filename cannot tell a
+        publication year from any other second year it happens to carry --
+        see test_a_second_year_that_is_a_scan_credit_stays_a_conflict_free_abstention
+        for the case where trusting it produces a false rejection.
         """
         assert issue_year_from_filename("Topolino 1904 (1992).cbz") is None
-        assert issue_year_from_filename("Topolino 1904 (1992).cbz", "1904") == 1992
+        assert issue_year_from_filename("Topolino 1904 (1992).cbz", "1904") is None
+
+    def test_a_second_year_that_is_a_scan_credit_stays_a_conflict_free_abstention(self):
+        """The false rejection that discarding before the count would create.
+
+        Italian scene releases routinely carry a second year that is a scan or
+        reprint date, not the publication date. "Topolino 1904 (c2c) (2008).cbz"
+        is issue #1904 (published 1992-05), scanned/reprinted in 2008. If the
+        issue number were discarded before the "exactly one candidate" count,
+        2008 would be promoted to the sole candidate and the check would
+        report a 16-year gap against the real 1992 date as a conflict,
+        throwing away a match the check otherwise abstains on. Counting first
+        means this filename keeps naming two years and the check still
+        abstains, issue number or not.
+        """
+        assert issue_year_from_filename(
+            "Topolino 1904 (c2c) (2008).cbz") is None
+        assert issue_year_from_filename(
+            "Topolino 1904 (c2c) (2008).cbz", "1904") is None
 
     def test_a_year_shaped_number_that_really_is_the_year_is_given_up(self):
         """The deliberate cost of the fix, recorded so it is a decision and not
@@ -150,10 +173,32 @@ class TestIssueNumberReadAsAYear:
                                         "1992") is None
 
     @pytest.mark.parametrize("number", [None, "", "  ", "1904A", "1904.1", "abc"])
-    def test_an_unusable_number_changes_nothing(self, number):
-        """Anything that is not a bare run of digits leaves the old behaviour
-        exactly as it was -- including a suffixed number, which never produced a
-        year anyway since _YEAR requires a non-alphanumeric on both sides."""
+    def test_a_number_that_does_not_match_the_candidate_year_changes_nothing(self, number):
+        """None of these read as the year 1940, whether or not they parse as a
+        number at all, so the sole candidate survives untouched."""
+        assert issue_year_from_filename("Batman 001 (1940).cbz", number) == 1940
+
+    @pytest.mark.parametrize("name,number", [
+        # "." is non-alphanumeric, so _YEAR matches "1904" inside these just as
+        # it would inside "Topolino 1904.cbz" -- the point issue keeps the
+        # exact bug this module exists to fix unless the leading integer run
+        # of the issue number, not the whole string, is what gets compared.
+        ("Topolino 1904.1.cbz", "1904.1"),
+        ("Topolino 1904.MU.cbz", "1904.MU"),
+        ("Topolino 1904.1.cbz", 1904.1),
+    ])
+    def test_a_decimal_or_lettered_point_issue_is_still_the_issue_number(self, name, number):
+        assert issue_year_from_filename(name, number) is None
+
+    @pytest.mark.parametrize("number", ["²", "①"])
+    def test_a_non_ascii_digit_never_raises(self, number):
+        """The module docstring promises these functions are pure and never
+        raise. `str.isdigit()` is True for characters outside ASCII 0-9 that
+        `int()` rejects -- the superscript '²' and the circled '①' -- so a
+        gate built on `str.isdigit()` alone would call `int()` on one of these
+        and raise ValueError. A regex match on `\\d` doesn't match either
+        character, so `_is_the_issue_number` returns False without ever
+        reaching `int()`."""
         assert issue_year_from_filename("Batman 001 (1940).cbz", number) == 1940
 
     def test_omitting_the_number_is_the_old_behaviour(self):

--- a/tests/unit/test_metadata_dates.py
+++ b/tests/unit/test_metadata_dates.py
@@ -92,6 +92,88 @@ class TestIssueYearFromFilename:
         assert issue_year_from_filename("Batman (1940) 001 1940.cbz") == 1940
 
 
+class TestIssueNumberReadAsAYear:
+    """A four-digit issue number looks exactly like a year, and used to be read
+    as one.
+
+    "Topolino 1904.cbz" is issue #1904 of a run that has passed #3,600. Nothing
+    in the string distinguishes those digits from the year in "Batman 001
+    (2016).cbz" -- a space before and a dot after, in both -- so the check
+    compared 1904 against the issue's real 1992 and rejected a correct match.
+    The only thing that tells them apart is that the caller has already read
+    those digits as the issue number.
+    """
+
+    @pytest.mark.parametrize("name,number", [
+        ("Topolino 1904.cbz", "1904"),
+        ("Topolino 2024.cbz", "2024"),
+        ("Diabolik 1985.cbr", "1985"),
+        # However the caller spells the number.
+        ("Topolino 1904.cbz", "01904"),
+        ("Topolino 1904.cbz", 1904),
+    ])
+    def test_the_issue_number_is_not_a_year(self, name, number):
+        assert issue_year_from_filename(name, number) is None
+
+    @pytest.mark.parametrize("name,number,expected", [
+        # The ordinary case: the year and the issue number are different
+        # numbers, and nothing changes.
+        ("Batman 001 (1940).cbz", "1", 1940),
+        ("Topolino 3221 (2017).cbz", "3221", 2017),
+        ("001 - Il re del terrore (Mondadori 1962-11).cbz", "1", 1962),
+    ])
+    def test_a_real_year_is_untouched(self, name, number, expected):
+        assert issue_year_from_filename(name, number) == expected
+
+    def test_it_also_rescues_a_file_the_check_used_to_skip(self):
+        """Discarding the number before counting candidates, not after.
+
+        "Topolino 1904 (1992).cbz" names two plausible years, so the check used
+        to abstain as ambiguous. One of them is the issue number, so once it is
+        dropped the remaining candidate is the year the file actually states and
+        the check can do its job.
+        """
+        assert issue_year_from_filename("Topolino 1904 (1992).cbz") is None
+        assert issue_year_from_filename("Topolino 1904 (1992).cbz", "1904") == 1992
+
+    def test_a_year_shaped_number_that_really_is_the_year_is_given_up(self):
+        """The deliberate cost of the fix, recorded so it is a decision and not
+        a surprise.
+
+        A yearbook numbered by its year -- "L'economia di Zio Paperone 1992" is
+        issue 1992, published in 1992 -- loses the check rather than passing it.
+        Giving up a check means the file is tagged as it was before the check
+        existed, which is a far smaller price than rejecting a correct match,
+        and there is no way to tell the two cases apart from the filename.
+        """
+        assert issue_year_from_filename("L'economia di Zio Paperone 1992.cbz",
+                                        "1992") is None
+
+    @pytest.mark.parametrize("number", [None, "", "  ", "1904A", "1904.1", "abc"])
+    def test_an_unusable_number_changes_nothing(self, number):
+        """Anything that is not a bare run of digits leaves the old behaviour
+        exactly as it was -- including a suffixed number, which never produced a
+        year anyway since _YEAR requires a non-alphanumeric on both sides."""
+        assert issue_year_from_filename("Batman 001 (1940).cbz", number) == 1940
+
+    def test_omitting_the_number_is_the_old_behaviour(self):
+        """Every existing caller that does not pass one keeps what it had."""
+        assert issue_year_from_filename("Topolino 1904.cbz") == 1904
+
+    def test_evaluate_passes_the_number_through(self, monkeypatch):
+        """The whole point: no conflict is raised for a correct match whose
+        issue number happens to look like a year."""
+        monkeypatch.setattr("core.metadata_dates.date_check_mode",
+                            lambda: MODE_ENFORCE)
+        monkeypatch.setattr("core.metadata_dates.date_check_tolerance", lambda: 2)
+
+        mode, conflicted, year = evaluate("Topolino 1904.cbz", "1992-05-24")
+        assert conflicted is True and year == 1904
+
+        mode, conflicted, year = evaluate("Topolino 1904.cbz", "1992-05-24", "1904")
+        assert conflicted is False and year is None
+
+
 class TestDateConflict:
 
     @pytest.mark.parametrize("issue_date", ["1999-06-01", "1999-06", "1999", 1999])


### PR DESCRIPTION
## 📝 Description
Closes #540

> **Updated 2026-09-03 in response to review.** Two corrections from
> [allaboutduncan's review](#pullrequestreview) below:
>
> 1. The issue-number candidate is now discarded **after** the "exactly one
>    year" count, not before it. Discarding first can promote an ambiguous
>    filename into a confident-but-wrong one whenever the filename carries a
>    *second* year that isn't the publication year — a scan or reprint year,
>    common in exactly the Italian scene releases this PR targets (e.g.
>    `Topolino 1904 (c2c) (2008).cbz`, issue #1904 published 1992, scanned
>    2008). That means the "ambiguous → checked" improvement this description
>    originally claimed for `Topolino 1904 (1992).cbz` is no longer part of
>    this PR — that file abstains exactly as it always did. What #540 actually
>    needed, `Topolino 1904.cbz` abstaining instead of rejecting, is
>    unaffected. The bullet list and invariant paragraph below are corrected
>    inline; the stats table further down was measured against the original
>    (before-the-count) implementation and has not been re-run against the
>    corrected one, so treat its exact figures as historical.
> 2. `_is_the_issue_number` now compares the issue number's *leading integer
>    run* instead of requiring the whole string to be digits, so decimal and
>    lettered point issues (`1904.1`, `1904.MU`) are recognised as the issue
>    number too — previously they kept the exact bug this PR exists to fix.
>    This also closes a second, smaller hole: `str.isdigit()` is `True` for
>    digit characters `int()` rejects (e.g. `'²'`, `'①'`), which the module
>    docstring's "pure and never raises" promised these functions wouldn't
>    hit; the regex form can't match those characters, so it never reaches
>    `int()` on them.

The date check reads a standalone four-digit number in the 1900–2099 range as a publication year.
`Topolino 1904.cbz` is issue #1904 of a run that has passed #3,600, so the check compares 1904
against the issue's real date of 1992-05-24, calls the 88-year gap a conflict, and under `enforce`
drops a match that was correct. The log then blames a date conflict, which points the
investigation the wrong way.

Nothing in the string separates the two cases. `Topolino 1904.cbz` and `Batman 001 (2016).cbz`
both put four digits between a non-alphanumeric on each side, which is exactly what `_YEAR` looks
for. The existing guards already handle everything that *can* be told apart from the filename
alone — `Hal2008` has a letter before, `1920px` a letter after, `v2004` a letter before. The one
thing distinguishing a year from an issue number here is that the caller has already read those
digits as the issue number, and the parser was never told.

So tell it. `issue_year_from_filename` and `evaluate` take an optional `issue_number`, and a
candidate year equal to it is discarded. The three call sites that run the check —
`accept_match` and the search-metadata path in `routes/metadata.py`, and `_date_conflicted` in
`core/bulk_metadata.py` — all have the number in scope already. A caller that passes nothing gets
exactly the old behaviour, which is what keeps this safe to land.

~~The candidate is discarded **before** the "exactly one year" test rather than after, and that
placement earns its keep in both directions:~~

**Corrected:** the candidate is discarded **after** the "exactly one year" test, not before it —
so it can only ever turn a single confident-but-wrong candidate into abstention, never manufacture
a new conflict out of an ambiguous filename:

- `Topolino 1904.cbz` names one candidate, 1904, which is the issue number, so the check abstains
  instead of rejecting. This is the whole fix for #540.
- ~~`Topolino 1904 (1992).cbz` goes from two candidates to one, so a file the check used to skip as
  ambiguous is now checked against the year it actually states.~~ **No longer true, and
  deliberately given up**: a filename naming two years stays ambiguous and the check still
  abstains, whether or not one of the two happens to equal the issue number — see the review
  discussion on `Topolino 1904 (c2c) (2008).cbz` for why promoting it would create a false
  rejection instead.

The change can only turn a conflict into no opinion, or no opinion into a real comparison. It
cannot produce a new false rejection, because the only year it removes is one the caller has
already committed to reading as the issue number, and it is only ever removed once that year is
already the sole candidate.

**What it costs.** A publication numbered by its year — a yearbook such as *L'economia di Zio
Paperone 1992*, issue 1992 published in 1992 — loses the check rather than passing it. Nothing is
written differently for those files, since a skipped check and a passed check both write the
metadata, and the filename cannot tell that case from the broken one. There is a test pinning it,
so it stays a recorded decision rather than a later surprise.

This is not specific to any provider: `core/metadata_dates.py` is shared, so GCD, ComicVine and
Metron are affected equally. It stays invisible in a library of American comics and is unavoidable
in one holding Topolino, Diabolik, Tex or Dylan Dog.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary — nothing to update; no new settings and no new dependencies
- [x] Verified build locally (`docker build -t dev .`)

Four files plus tests: the parser and `evaluate` in `core/metadata_dates.py`, the two call sites in
`routes/metadata.py` (now guarded by a wiring regression test), one in `core/bulk_metadata.py`
(now passing the filename-derived issue number instead of the provider's own copy of it).

## 🧪 Testing Performed
- [x] Manual test in `dev` container
- [x] Linting/Unit tests pass (see review-response commit for the updated count)

**Before and after, in two containers with identical inputs**: a local ComicVine SQLite database
holding volume "Topolino" with an issue numbered `1904` dated `1992-05-24`, one file
`/data/Topolino/Topolino 1904.cbz`, a `cvinfo` naming the volume, and `date_check_mode` set to
`enforce`.

On `main` at 7e0f867 the correct match is thrown away:

```
Date conflict for Topolino 1904.cbz: filename says 1904, matched issue is dated 1992-05
Rejected ComicVine (Local DB) match for Topolino 1904.cbz: issue date contradicts the filename year 1904
```
```json
{"processed": 0, "errors": 1, "details": [
  {"file": "Topolino 1904.cbz", "status": "error", "reason": "date conflict", "date_conflict": true}]}
```

On this branch, same database, same file, same enforce setting:

```json
{"processed": 1, "errors": 0, "details": [
  {"file": "Topolino 1904.cbz", "status": "success", "source": "ComicVine (Local DB)"}]}
```
```
update_file_index_from_comicinfo: series=Topolino, number=1904, title=Topolino 1904,
                                  year=1992, publisher=Mondadori, writer=Romano Scarpa
```

Every pre-existing test calls `issue_year_from_filename(name)` with no number, so it takes the
default and hits the old path unchanged. Backwards compatibility is demonstrated by the untouched
suite rather than asserted.

> **The table below predates the review fixes** and was measured against the original
> before-the-count discard. It has not been re-run against the corrected after-the-count version,
> so the exact counts (in particular "gains a year" and "was rejected, now accepted") are no
> longer accurate for this branch — the corrected version discards strictly fewer candidates, so
> real counts here would be lower. Left in place as a record of the methodology and of the one
> real bug it caught (the `[c2c Hal 2008]` bracket-parsing flip below), which is unaffected by the
> review fixes.

Beyond that, the old and new parsers were run side by side over a real 5,369-file library, and
every file whose parse changed was scored against the matched issue's actual publication date:

| | Files |
| --- | ---: |
| Parses identically | 4,406 |
| Loses a year | 49 |
| Gains a year the check could not use before | 58 |

| Verdict change | Files |
| --- | ---: |
| Was rejected, now accepted | **36** |
| Was accepted, now rejected | **1** |

That single flip is correct, and worth spelling out because it looks like a regression:
`Topolino 0330 (Mondadori 1962-03-25) [c2c Hal 2008 & Bibbo64].cbr`. `extract_issue_number`
returns `2008` rather than `330` here, because it strips parentheses but not square brackets, so
the file matches issue #2008 — published 1994 — when it is issue #330 from 1962. Previously the
filename named two years, the check abstained, and the wrong metadata was written silently. Now
2008 is discarded as the issue number, 1962 remains, and the mismatch is caught.

That bracket-parsing detail is a separate bug and this PR does not touch it.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C2zch6Fz6z2WxRnVNCa2XZ
https://claude.ai/code/session_01Q8MJHCSmP9Sx7GARqxLShc
