### PR TITLE
Keep the Store Owner signed in when the first extra account is added

### DIFF
--- a/core/database.py
+++ b/core/database.py
@@ -8750,10 +8750,63 @@ def delete_user(user_id):
         conn.close()
 
 
+def adopt_env_credentials_for_placeholder_owner():
+    """Give a passwordless placeholder owner the CLU_USERNAME/CLU_PASSWORD
+    credentials, when they are set (idempotent; runs at startup).
+
+    seed_owner_if_needed() reads those env vars only on a database with no
+    users at all, so an install whose owner is still the first-run placeholder
+    cannot use them to get back in. That install can be locked out with no way
+    to authenticate: login is required — because the env gate is set, or
+    because a second account exists — while the only account that could satisfy
+    it has no password, and /setup-owner is behind the same gate.
+
+    Adopting the credentials here is the way back in, and it opens no door that
+    was not already open: setting them takes control of the container
+    environment, which already implies full access to this database.
+    """
+    owner = get_owner_user()
+    if not owner or not owner.get("needs_setup"):
+        return  # a configured owner keeps the credentials they already have
+
+    username = os.environ.get("CLU_USERNAME", "").strip()
+    password = os.environ.get("CLU_PASSWORD", "")
+    if not username or not password:
+        if count_users() > 1:
+            # Login is required and the owner cannot satisfy it. Say so at
+            # startup rather than leaving the operator to guess from a login
+            # screen that rejects every password.
+            app_logger.error(
+                "The Store Owner account has no password and this install "
+                "requires login: nobody can sign in. Set CLU_USERNAME and "
+                "CLU_PASSWORD and restart to give the owner credentials."
+            )
+        return
+
+    clash = get_user_by_username(username)
+    if clash and clash["id"] != owner["id"]:
+        app_logger.warning(
+            f"CLU_USERNAME '{username}' belongs to another account; applying "
+            f"CLU_PASSWORD to the Store Owner under its own username "
+            f"'{owner['username']}'"
+        )
+    else:
+        update_user(owner["id"], username=username)
+        owner = get_owner_user()
+
+    set_user_password(owner["id"], password)  # also clears needs_setup
+    app_logger.info(
+        f"Store Owner '{owner['username']}' adopted the credentials from "
+        "CLU_USERNAME/CLU_PASSWORD (the account had none)"
+    )
+
+
 def seed_owner_if_needed():
     """Ensure a Store Owner account exists (idempotent; runs at startup).
 
-    - If any users already exist, do nothing.
+    - If any users already exist, only adopt CLU_USERNAME/CLU_PASSWORD onto a
+      placeholder owner that still has no password (see
+      adopt_env_credentials_for_placeholder_owner).
     - Else if CLU_USERNAME/CLU_PASSWORD are set, migrate them into a hashed
       owner account.
     - Else create a passwordless placeholder owner (needs_setup=1) so
@@ -8764,6 +8817,7 @@ def seed_owner_if_needed():
     row so the current mobile client keeps working.
     """
     if count_users() > 0:
+        adopt_env_credentials_for_placeholder_owner()
         return
 
     username = os.environ.get("CLU_USERNAME", "").strip()

--- a/core/database.py
+++ b/core/database.py
@@ -8343,6 +8343,39 @@ def count_users():
             pass
 
 
+def count_owners_who_can_sign_in():
+    """Return how many Store Owners could actually satisfy a login prompt.
+
+    An account can sign in only if it is active and holds a password hash, so
+    a first-run placeholder owner (needs_setup, password_hash NULL) counts for
+    nothing. Owners specifically, not any account: a reader who can log in
+    leaves /config, user management and first-run setup all unreachable, which
+    is the lock-out worth reporting.
+
+    Used by the startup lock-out diagnostic; like count_users() this must never
+    raise, and it returns 0 when the table or DB is unavailable.
+    """
+    conn = get_db_connection()
+    if not conn:
+        return 0
+    try:
+        c = conn.cursor()
+        c.execute(
+            "SELECT COUNT(*) FROM users "
+            "WHERE role = 'owner' AND is_active = 1 "
+            "AND password_hash IS NOT NULL AND password_hash != ''"
+        )
+        row = c.fetchone()
+        return int(row[0]) if row and row[0] is not None else 0
+    except Exception:
+        return 0  # table missing, DB corrupt, or unexpected shape
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+
 def get_owner_user():
     """Return the Store Owner account (lowest-id 'owner' role), or None.
 
@@ -8772,14 +8805,24 @@ def adopt_env_credentials_for_placeholder_owner():
     username = os.environ.get("CLU_USERNAME", "").strip()
     password = os.environ.get("CLU_PASSWORD", "")
     if not username or not password:
-        if count_users() > 1:
-            # Login is required and the owner cannot satisfy it. Say so at
-            # startup rather than leaving the operator to guess from a login
-            # screen that rejects every password.
+        # Report the actual lock-out, not a proxy for it. "Login is on" is
+        # is_login_required(): count_users() > 1 misses the env gate, which can
+        # be on with a single user, and which reads the raw env values rather
+        # than the stripped ones above. "No owner can get in" is a count of
+        # *owners* holding a usable password — get_owner_user() returns the
+        # lowest-id owner, so a second, configured owner keeps the install
+        # administrable and there is nothing to report, while a reader who can
+        # log in does not (it leaves /config and user management unreachable).
+        from core.auth import is_login_required  # local: core.auth imports us
+
+        if is_login_required() and count_owners_who_can_sign_in() == 0:
+            # Say so at startup rather than leaving the operator to guess from
+            # a login screen that rejects every password.
             app_logger.error(
                 "The Store Owner account has no password and this install "
-                "requires login: nobody can sign in. Set CLU_USERNAME and "
-                "CLU_PASSWORD and restart to give the owner credentials."
+                "requires login: nobody can sign in as Store Owner. Set "
+                "CLU_USERNAME and CLU_PASSWORD and restart to give the owner "
+                "credentials."
             )
         return
 
@@ -8791,10 +8834,29 @@ def adopt_env_credentials_for_placeholder_owner():
             f"'{owner['username']}'"
         )
     else:
-        update_user(owner["id"], username=username)
-        owner = get_owner_user()
+        if update_user(owner["id"], username=username):
+            owner = get_owner_user()
+        else:
+            # update_user swallows its own write failures, so without this the
+            # rename is lost silently and the operator is told to log in under
+            # a username the account never got.
+            app_logger.warning(
+                f"Could not apply CLU_USERNAME '{username}' to the Store "
+                f"Owner; keeping its existing username '{owner['username']}'"
+            )
 
-    set_user_password(owner["id"], password)  # also clears needs_setup
+    # Report the outcome, not the attempt. Both writers return False on a
+    # failure they have already swallowed, and an operator recovering a
+    # locked-out install reads the success line as confirmation: they restart,
+    # are rejected at the login form again, and have nothing to go on.
+    if not set_user_password(owner["id"], password):  # also clears needs_setup
+        app_logger.error(
+            f"Failed to apply CLU_PASSWORD to the Store Owner "
+            f"'{owner['username']}'; the account still has no password and "
+            "nobody can sign in. Check the logs above for a database error."
+        )
+        return
+
     app_logger.info(
         f"Store Owner '{owner['username']}' adopted the credentials from "
         "CLU_USERNAME/CLU_PASSWORD (the account had none)"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -45,8 +45,13 @@ services:
             # mount it into the container, and point CLU at it (or set the path in
             # Config -> Metadata Providers instead of using this env var).
             #- GCD_DATABASE_PATH=/config/gcd.db
-            - CLU_USERNAME=[USERNAME]
-            - CLU_PASSWORD=[PASSWORD]
+            ## Login credentials belong in the CLU_USERNAME/CLU_PASSWORD pair
+            ## near the top of this block. These placeholders stay commented
+            ## out: left live, the install runs with a username and password
+            ## published in this repository, and an owner account still
+            ## awaiting first-run setup adopts them at startup.
+            #- CLU_USERNAME=[USERNAME]
+            #- CLU_PASSWORD=[PASSWORD]
         #networks:
         #    - gcd-network
 

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -166,6 +166,9 @@ def create_user_route():
     if owner and owner.get("needs_setup") and not is_login_required():
         return jsonify({
             "success": False,
+            # The page keys off this to close the dialog: nothing in the form
+            # can fix this, so the message has to be readable behind it.
+            "code": "owner_needs_setup",
             "error": "Set the Store Owner's username and password first — "
                      "adding a second account turns on login, and the owner "
                      "has no password yet.",

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -7,10 +7,10 @@ optional CLU_USERNAME/CLU_PASSWORD session gate). They are *not* under
 and the token managed here is the very thing it authenticates against.
 """
 
-from flask import Blueprint, Response, jsonify, request
+from flask import Blueprint, Response, jsonify, request, session
 
 from core.app_logging import app_logger
-from core.auth import require_role
+from core.auth import current_user, is_login_required, require_role
 from core.database import (
     count_owners,
     create_api_token,
@@ -157,6 +157,20 @@ def create_user_route():
     if role not in VALID_ROLES:
         return jsonify({"success": False, "error": "invalid role"}), 400
 
+    # A second account ends implicit-owner mode and turns login on for
+    # everyone (core.auth.is_login_required). A placeholder owner has no
+    # password and cannot authenticate, so that flip would lock every user out
+    # of the install permanently. Refuse until first-run setup has given the
+    # owner real credentials.
+    owner = get_owner_user()
+    if owner and owner.get("needs_setup") and not is_login_required():
+        return jsonify({
+            "success": False,
+            "error": "Set the Store Owner's username and password first — "
+                     "adding a second account turns on login, and the owner "
+                     "has no password yet.",
+        }), 409
+
     user_id = create_user(username, password=password, role=role,
                           display_name=display_name, email=email)
     if not user_id:
@@ -169,6 +183,19 @@ def create_user_route():
         set_user_libraries(user_id, library_ids)
     if folder_paths:
         set_user_folders(user_id, folder_paths)
+
+    # This account may have just turned login on. In implicit-owner mode the
+    # owner never logged in, so they hold no session and would be anonymous on
+    # their very next request — the page reports a failure and bounces them to
+    # /login moments after a successful create. Persist the identity this
+    # browser was already acting under so the flip is invisible to it. Only the
+    # browser that made the call is stamped, and only when it was already the
+    # owner, so it gains no privilege it did not have a moment ago.
+    if not session.get("user_id"):
+        acting = current_user()
+        if acting and acting.get("role") == "owner":
+            session["user_id"] = acting["id"]
+            session["authenticated"] = True  # legacy flag, kept for compatibility
 
     return jsonify({"success": True, "user": _user_payload(get_user_by_id(user_id))}), 201
 

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -194,11 +194,19 @@ def create_user_route():
     # browser was already acting under so the flip is invisible to it. Only the
     # browser that made the call is stamped, and only when it was already the
     # owner, so it gains no privilege it did not have a moment ago.
-    if not session.get("user_id"):
-        acting = current_user()
-        if acting and acting.get("role") == "owner":
-            session["user_id"] = acting["id"]
-            session["authenticated"] = True  # legacy flag, kept for compatibility
+    #
+    # The session is compared against the resolved identity rather than merely
+    # tested for emptiness. A browser can hold a user_id that no longer
+    # resolves: deleting or deactivating the only other account drops the
+    # install back to implicit-owner mode, where resolve_current_user() falls
+    # through to the owner and that browser acts as the owner with a stale id
+    # still in its cookie. Treating that truthy-but-dead value as "already
+    # stamped" would skip the stamp and reproduce the very lock-out this
+    # guards against.
+    acting = current_user()
+    if acting and acting.get("role") == "owner" and session.get("user_id") != acting["id"]:
+        session["user_id"] = acting["id"]
+        session["authenticated"] = True  # legacy flag, kept for compatibility
 
     return jsonify({"success": True, "user": _user_payload(get_user_by_id(user_id))}), 201
 

--- a/templates/users.html
+++ b/templates/users.html
@@ -158,8 +158,10 @@ async function loadUsers() {
     const status = u.is_active
       ? "<span class='badge bg-success'>Active</span>"
       : "<span class='badge bg-secondary'>Disabled</span>";
+    // Link the badge to first-run setup: adding a second account is refused
+    // while the owner has no password, so this is the way out of that state.
     const setup = u.needs_setup
-      ? " <span class='badge bg-danger'>Needs setup</span>" : "";
+      ? " <a href='/setup-owner' class='badge bg-danger text-decoration-none'>Needs setup</a>" : "";
     return `<tr>
       <td>${esc(u.username)}${setup}</td>
       <td>${esc(u.display_name || "")}</td>

--- a/templates/users.html
+++ b/templates/users.html
@@ -405,6 +405,10 @@ function selectedLibs() {
   return Array.from(document.querySelectorAll(".lib-check:checked")).map(c => parseInt(c.value, 10));
 }
 
+function hideUserModal() {
+  bootstrap.Modal.getInstance(document.getElementById("userModal")).hide();
+}
+
 async function saveUser() {
   const id = document.getElementById("f-id").value;
   const payload = {
@@ -427,9 +431,12 @@ async function saveUser() {
   });
   const data = await resp.json().catch(() => ({}));
   if (!resp.ok || !data.success) {
+    // Most errors are fixable in the form, so the dialog stays open over the
+    // alert. First-run setup is not: close it so the message can be read.
+    if (data.code === "owner_needs_setup") hideUserModal();
     alertMsg(data.error || "Save failed."); return;
   }
-  bootstrap.Modal.getInstance(document.getElementById("userModal")).hide();
+  hideUserModal();
   alertMsg("Saved.", "success");
   loadUsers();
 }

--- a/tests/integration/test_users.py
+++ b/tests/integration/test_users.py
@@ -307,6 +307,55 @@ class TestPlaceholderOwnerAdoptsEnvCredentials:
         assert owner["needs_setup"] == 0
         assert verify_password(ENV_OWNER, ENV_OWNER_KEY)["role"] == "owner"
 
+    def test_env_gate_alone_reaches_the_placeholder_owner(
+            self, db_connection, monkeypatch):
+        """No second account needed: the gate itself demands a login.
+
+        Turning on CLU_USERNAME/CLU_PASSWORD — which is what the compose file
+        tells an operator to do to require login — locks an install that never
+        ran first-run setup, because is_login_required() is true from the env
+        gate while the sole account has no password.
+        """
+        seed_owner_if_needed()  # placeholder owner, and the only account
+        assert count_users() == 1
+
+        _set_env_gate(monkeypatch)
+        seed_owner_if_needed()
+
+        assert count_users() == 1  # still no second account
+        assert get_owner_user()["needs_setup"] == 0
+        assert verify_password(ENV_OWNER, ENV_OWNER_KEY)["role"] == "owner"
+
+    def test_says_so_when_nobody_can_sign_in(self, db_connection, monkeypatch,
+                                             caplog):
+        """Without the env vars the install stays stuck — log that, loudly."""
+        import logging
+
+        monkeypatch.delenv("CLU_USERNAME", raising=False)
+        monkeypatch.delenv("CLU_PASSWORD", raising=False)
+        seed_owner_if_needed()
+        create_user("kid", password="pw", role="reader")  # login now required
+
+        with caplog.at_level(logging.ERROR, logger="app_logger"):
+            adopt_env_credentials_for_placeholder_owner()
+
+        assert any("nobody can sign in" in rec.message for rec in caplog.records), \
+            f"expected a startup error; got: {[r.message for r in caplog.records]}"
+
+    def test_stays_quiet_while_the_install_is_still_reachable(
+            self, db_connection, monkeypatch, caplog):
+        """One account means no login is required — nothing is wrong yet."""
+        import logging
+
+        monkeypatch.delenv("CLU_USERNAME", raising=False)
+        monkeypatch.delenv("CLU_PASSWORD", raising=False)
+        seed_owner_if_needed()
+
+        with caplog.at_level(logging.ERROR, logger="app_logger"):
+            adopt_env_credentials_for_placeholder_owner()
+
+        assert not [r for r in caplog.records if "nobody can sign in" in r.message]
+
     def test_configured_owner_keeps_its_own_password(
             self, db_connection, monkeypatch):
         """Never override credentials somebody has already set."""

--- a/tests/integration/test_users.py
+++ b/tests/integration/test_users.py
@@ -10,6 +10,7 @@ import pytest
 from core.auth import ROLE_LEVELS, role_at_least
 from core.database import (
     _hash_token,
+    adopt_env_credentials_for_placeholder_owner,
     count_users,
     create_api_token,
     create_user,
@@ -268,3 +269,85 @@ class TestSeedOwner:
         # The old global token now resolves to the owner via api_tokens.
         user = get_user_by_token_hash(_hash_token("legacy-token-123"))
         assert user and user["id"] == owner["id"]
+
+
+# ---------------------------------------------------------------------------
+# Recovering an install whose owner never got a password
+# ---------------------------------------------------------------------------
+# The CLU_USERNAME/CLU_PASSWORD pair an operator would put in the compose file.
+ENV_OWNER, ENV_OWNER_KEY = "envboss", "envpw"
+
+
+def _set_env_gate(monkeypatch):
+    """Set the env credential gate the way the compose file documents it."""
+    monkeypatch.setenv("CLU_USERNAME", ENV_OWNER)
+    monkeypatch.setenv("CLU_PASSWORD", ENV_OWNER_KEY)
+
+
+class TestPlaceholderOwnerAdoptsEnvCredentials:
+    """CLU_USERNAME/CLU_PASSWORD are the way back into a locked-out install.
+
+    A placeholder owner has no password, so once login is required — the env
+    gate itself, or a second account — nothing can authenticate and even
+    /setup-owner is behind the gate. seed_owner_if_needed() reads the env vars
+    only on an empty database, so these cover the non-empty case.
+    """
+
+    def test_placeholder_owner_takes_the_env_credentials(
+            self, db_connection, monkeypatch):
+        seed_owner_if_needed()  # placeholder owner, no password
+        create_user("kid", password="pw", role="reader")  # login now required
+        assert get_owner_user()["needs_setup"] == 1
+
+        _set_env_gate(monkeypatch)
+        seed_owner_if_needed()
+
+        owner = get_owner_user()
+        assert owner["username"] == ENV_OWNER
+        assert owner["needs_setup"] == 0
+        assert verify_password(ENV_OWNER, ENV_OWNER_KEY)["role"] == "owner"
+
+    def test_configured_owner_keeps_its_own_password(
+            self, db_connection, monkeypatch):
+        """Never override credentials somebody has already set."""
+        create_user("boss", password="pw", role="owner")
+        _set_env_gate(monkeypatch)
+
+        adopt_env_credentials_for_placeholder_owner()
+
+        assert get_owner_user()["username"] == "boss"
+        assert verify_password("boss", "pw")
+        assert verify_password(ENV_OWNER, ENV_OWNER_KEY) is None
+
+    def test_username_taken_keeps_the_owner_name(self, db_connection, monkeypatch):
+        seed_owner_if_needed()
+        create_user(ENV_OWNER, password="pw", role="reader")  # CLU_USERNAME clashes
+        _set_env_gate(monkeypatch)
+
+        adopt_env_credentials_for_placeholder_owner()
+
+        owner = get_owner_user()
+        assert owner["username"] == "owner"  # not renamed onto the clash
+        assert verify_password("owner", ENV_OWNER_KEY)["role"] == "owner"
+        assert verify_password(ENV_OWNER, "pw")["role"] == "reader"  # untouched
+
+    def test_no_env_credentials_changes_nothing(self, db_connection, monkeypatch):
+        monkeypatch.delenv("CLU_USERNAME", raising=False)
+        monkeypatch.delenv("CLU_PASSWORD", raising=False)
+        seed_owner_if_needed()
+        create_user("kid", password="pw", role="reader")
+
+        adopt_env_credentials_for_placeholder_owner()
+
+        assert get_owner_user()["needs_setup"] == 1
+
+    def test_is_idempotent(self, db_connection, monkeypatch):
+        seed_owner_if_needed()
+        create_user("kid", password="pw", role="reader")
+        _set_env_gate(monkeypatch)
+
+        adopt_env_credentials_for_placeholder_owner()
+        adopt_env_credentials_for_placeholder_owner()
+
+        assert count_users() == 2
+        assert verify_password(ENV_OWNER, ENV_OWNER_KEY)

--- a/tests/routes/test_rbac.py
+++ b/tests/routes/test_rbac.py
@@ -500,6 +500,44 @@ class TestFirstAdditionalUser:
         other = app.test_client()
         assert other.get("/api/admin/users").status_code == 401
 
+    def test_stale_session_id_does_not_skip_the_stamp(
+            self, client, db_connection, app):
+        """A browser holding a dead user_id must still be stamped as the owner.
+
+        Deleting the only other account drops the install back to
+        implicit-owner mode, so a browser whose cookie still names the deleted
+        account resolves to the owner again — acting as the owner with a
+        truthy-but-dead id in its session. Treating that id as "already
+        stamped" would skip the stamp and log that browser out the instant it
+        created the next account, which is the bug this whole guard exists to
+        prevent.
+        """
+        self._setup_owner(client)
+        assert client.post("/api/admin/users", json={
+            "username": "kid", "password": "pw", "role": "reader",
+        }).status_code == 201
+        kid_id = get_user_by_username("kid")["id"]
+
+        # A second browser signs in as the reader, so it holds user_id=<kid>.
+        other = app.test_client()
+        _login(other, "kid", "pw")
+        # 403 (not 401) confirms the reader is authenticated in this browser.
+        assert other.get("/api/admin/users").status_code == 403
+
+        # The owner removes that account: one user left, implicit-owner mode.
+        assert client.delete(f"/api/admin/users/{kid_id}").status_code == 200
+        assert count_users() == 1
+
+        # The stale cookie no longer resolves, so this browser is the owner.
+        assert other.get("/api/admin/users").status_code == 200
+
+        assert other.post("/api/admin/users", json={
+            "username": "kid2", "password": "pw", "role": "reader",
+        }).status_code == 201
+
+        # Login is on again; without the stamp this browser is now anonymous.
+        assert other.get("/api/admin/users").status_code == 200
+
     def test_placeholder_owner_cannot_turn_login_on(self, client, db_connection):
         """An owner with no password must not be able to lock the install."""
         seed_owner_if_needed()  # placeholder: needs_setup, no password

--- a/tests/routes/test_rbac.py
+++ b/tests/routes/test_rbac.py
@@ -9,6 +9,7 @@ import pytest
 
 from core.auth import required_role_for_request
 from core.database import (
+    adopt_env_credentials_for_placeholder_owner,
     count_users,
     create_user,
     get_owner_user,
@@ -530,3 +531,48 @@ class TestFirstAdditionalUser:
         assert client.get("/api/admin/users").status_code == 401
         _login(client, "boss", "hunter2")
         assert client.get("/api/admin/users").status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Getting back into an install that is already locked out
+# ---------------------------------------------------------------------------
+# The CLU_USERNAME/CLU_PASSWORD pair an operator would put in the compose file.
+ENV_OWNER, ENV_OWNER_KEY = "envboss", "envpw"
+
+
+class TestLockedOutInstallRecovery:
+    """The whole way back in, through the real login form.
+
+    An install carrying the bug this module covers holds a passwordless owner
+    and a second account, so login is required and nothing can satisfy it.
+    Setting CLU_USERNAME/CLU_PASSWORD and restarting has to end with the owner
+    actually signed in — not merely with a password hash in the table.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _locked_out_install(self, db_connection, monkeypatch):
+        monkeypatch.delenv("CLU_USERNAME", raising=False)
+        monkeypatch.delenv("CLU_PASSWORD", raising=False)
+        seed_owner_if_needed()                          # placeholder owner
+        create_user("kid", password="pw", role="reader")  # login now required
+        yield
+
+    def test_locked_out_before_the_env_vars_are_set(self, client):
+        assert client.get("/api/admin/users").status_code == 401
+        assert client.post("/login", data={
+            "username": "owner", "password": "",
+        }).status_code == 200  # the form re-renders: no credentials to match
+
+    def test_env_credentials_restore_access_through_the_login_form(
+            self, client, monkeypatch):
+        monkeypatch.setenv("CLU_USERNAME", ENV_OWNER)
+        monkeypatch.setenv("CLU_PASSWORD", ENV_OWNER_KEY)
+        adopt_env_credentials_for_placeholder_owner()  # runs at startup
+
+        resp = _login(client, ENV_OWNER, ENV_OWNER_KEY)
+        assert resp.status_code == 302  # redirected in, not re-rendered
+
+        data = client.get("/api/admin/users").get_json()
+        assert data["success"] is True
+        assert {u["username"] for u in data["users"]} == {ENV_OWNER, "kid"}
+        assert client.get("/config").status_code == 200

--- a/tests/routes/test_rbac.py
+++ b/tests/routes/test_rbac.py
@@ -508,6 +508,8 @@ class TestFirstAdditionalUser:
             "username": "kid", "password": "pw", "role": "reader",
         })
         assert resp.status_code == 409
+        # The page keys off this code to close its dialog over the message.
+        assert resp.get_json()["code"] == "owner_needs_setup"
         assert count_users() == 1  # nothing created
 
         # The install is still reachable, and first-run setup still works.

--- a/tests/routes/test_rbac.py
+++ b/tests/routes/test_rbac.py
@@ -11,10 +11,12 @@ from core.auth import required_role_for_request
 from core.database import (
     adopt_env_credentials_for_placeholder_owner,
     count_users,
+    count_owners_who_can_sign_in,
     create_user,
     get_owner_user,
     get_user_by_username,
     seed_owner_if_needed,
+    update_user,
     verify_password,
 )
 
@@ -614,3 +616,122 @@ class TestLockedOutInstallRecovery:
         assert data["success"] is True
         assert {u["username"] for u in data["users"]} == {ENV_OWNER, "kid"}
         assert client.get("/config").status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# The startup lock-out diagnostic
+# ---------------------------------------------------------------------------
+class TestLockoutDiagnostic:
+    """adopt_env_credentials_for_placeholder_owner()'s startup ERROR line.
+
+    It exists so an operator whose install nobody can sign into learns why at
+    startup instead of guessing at a login form. That makes a wrong line worse
+    than none: a false alarm sends them hunting a problem they do not have, and
+    a missed one leaves the real lock-out unexplained.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _no_env(self, db_connection, monkeypatch):
+        monkeypatch.delenv("CLU_USERNAME", raising=False)
+        monkeypatch.delenv("CLU_PASSWORD", raising=False)
+
+    @staticmethod
+    def _lockout_errors(caplog):
+        return [r for r in caplog.records
+                if r.levelname == "ERROR" and "nobody can sign in" in r.message]
+
+    def test_silent_when_another_owner_can_sign_in(self, caplog):
+        """get_owner_user() is the *lowest-id* owner, not the only one."""
+        seed_owner_if_needed()               # placeholder owner at id 1
+        create_user("boss2", password="pw", role="owner")  # a working owner
+
+        with caplog.at_level("ERROR"):
+            adopt_env_credentials_for_placeholder_owner()
+
+        # Login is required (two accounts) and the id-1 owner has no password,
+        # but boss2 signs in fine, so there is no lock-out to report.
+        assert count_users() > 1
+        assert self._lockout_errors(caplog) == []
+
+    def test_reports_lockout_behind_a_whitespace_env_username(
+            self, caplog, monkeypatch):
+        """The env gate reads raw values; adoption strips them."""
+        seed_owner_if_needed()  # placeholder owner, the only account
+        monkeypatch.setenv("CLU_USERNAME", "   ")
+        monkeypatch.setenv("CLU_PASSWORD", "pw")
+
+        with caplog.at_level("ERROR"):
+            adopt_env_credentials_for_placeholder_owner()
+
+        # Only one account, so the old count_users() > 1 proxy stayed quiet
+        # while the env gate had login on and no password existed to satisfy it.
+        assert count_users() == 1
+        assert len(self._lockout_errors(caplog)) == 1
+
+    def test_silent_on_an_ordinary_single_user_install(self, caplog):
+        seed_owner_if_needed()  # placeholder owner, no env gate: login is off
+
+        with caplog.at_level("ERROR"):
+            adopt_env_credentials_for_placeholder_owner()
+
+        assert self._lockout_errors(caplog) == []
+
+    def test_counts_only_owners_who_could_actually_sign_in(self):
+        seed_owner_if_needed()  # placeholder: needs_setup, no password_hash
+        assert count_owners_who_can_sign_in() == 0
+
+        # A reader with a password is not a way back in: /config and user
+        # management stay unreachable, so it must not count.
+        create_user("kid", password="pw", role="reader")
+        assert count_owners_who_can_sign_in() == 0
+
+        boss_id = create_user("boss2", password="pw", role="owner")
+        assert count_owners_who_can_sign_in() == 1
+
+        update_user(boss_id, is_active=False)  # deactivated: cannot sign in
+        assert count_owners_who_can_sign_in() == 0
+
+
+# ---------------------------------------------------------------------------
+# A failed adoption must not log success
+# ---------------------------------------------------------------------------
+class TestAdoptionReportsItsOutcome:
+    """update_user() and set_user_password() swallow their write failures.
+
+    An operator recovering a locked-out install reads the success line as
+    confirmation: they restart, are rejected at the login form again, and have
+    nothing in the log to go on.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _placeholder_owner_with_env(self, db_connection, monkeypatch):
+        seed_owner_if_needed()
+        monkeypatch.setenv("CLU_USERNAME", ENV_OWNER)
+        monkeypatch.setenv("CLU_PASSWORD", ENV_OWNER_KEY)
+
+    def test_failed_password_write_is_reported_not_celebrated(
+            self, caplog, monkeypatch):
+        monkeypatch.setattr("core.database.set_user_password",
+                            lambda *a, **k: False)
+
+        with caplog.at_level("INFO"):
+            adopt_env_credentials_for_placeholder_owner()
+
+        assert not [r for r in caplog.records if "adopted the credentials" in r.message]
+        assert [r for r in caplog.records
+                if r.levelname == "ERROR" and "Failed to apply CLU_PASSWORD" in r.message]
+
+    def test_failed_rename_still_sets_the_password(self, caplog, monkeypatch):
+        """A lost username must not cost the operator the way back in."""
+        monkeypatch.setattr("core.database.update_user", lambda *a, **k: False)
+
+        with caplog.at_level("WARNING"):
+            adopt_env_credentials_for_placeholder_owner()
+
+        assert [r for r in caplog.records
+                if r.levelname == "WARNING" and "Could not apply CLU_USERNAME" in r.message]
+        # The owner keeps its original username, but can now sign in with it.
+        owner = get_owner_user()
+        assert owner["needs_setup"] == 0
+        assert verify_password(owner["username"], ENV_OWNER_KEY)
+

--- a/tests/routes/test_rbac.py
+++ b/tests/routes/test_rbac.py
@@ -9,6 +9,7 @@ import pytest
 
 from core.auth import required_role_for_request
 from core.database import (
+    count_users,
     create_user,
     get_owner_user,
     get_user_by_username,
@@ -440,3 +441,90 @@ class TestSetupOwner:
             "username": "x", "password": "y",
         })
         assert resp.status_code == 409
+
+
+# ---------------------------------------------------------------------------
+# Leaving implicit-owner mode: the first *additional* account turns login on
+# ---------------------------------------------------------------------------
+class TestFirstAdditionalUser:
+    """Adding the second account flips is_login_required() from False to True.
+
+    Before the flip nobody has ever logged in, so the owner holds no session.
+    These cover the two ways that used to go wrong: the owner being logged out
+    the instant the account was created, and a placeholder owner turning login
+    on for an install where no password exists to log in with.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _no_env_gate(self, monkeypatch):
+        monkeypatch.delenv("CLU_USERNAME", raising=False)
+        monkeypatch.delenv("CLU_PASSWORD", raising=False)
+
+    def _setup_owner(self, client):
+        seed_owner_if_needed()
+        resp = client.post("/api/admin/setup-owner", json={
+            "username": "boss", "password": "hunter2",
+        })
+        assert resp.status_code == 200
+
+    def test_owner_keeps_access_after_creating_the_first_user(
+            self, client, db_connection):
+        self._setup_owner(client)
+
+        resp = client.post("/api/admin/users", json={
+            "username": "kid", "password": "pw", "role": "reader",
+        })
+        assert resp.status_code == 201
+
+        # Login is now required; the owner's browser must still be the owner.
+        resp = client.get("/api/admin/users")
+        assert resp.status_code == 200
+        assert {u["username"] for u in resp.get_json()["users"]} == {"boss", "kid"}
+
+    def test_owner_keeps_access_to_browser_pages_too(self, client, db_connection):
+        self._setup_owner(client)
+        client.post("/api/admin/users", json={
+            "username": "kid", "password": "pw", "role": "reader",
+        })
+        # Owner-only browser page: a redirect here is the logout users reported.
+        assert client.get("/config").status_code == 200
+
+    def test_creating_a_user_does_not_authenticate_a_bystander(
+            self, client, db_connection, app):
+        """Only the browser that made the call is signed in, not every client."""
+        self._setup_owner(client)
+        client.post("/api/admin/users", json={
+            "username": "kid", "password": "pw", "role": "reader",
+        })
+        other = app.test_client()
+        assert other.get("/api/admin/users").status_code == 401
+
+    def test_placeholder_owner_cannot_turn_login_on(self, client, db_connection):
+        """An owner with no password must not be able to lock the install."""
+        seed_owner_if_needed()  # placeholder: needs_setup, no password
+        assert get_owner_user()["needs_setup"] == 1
+
+        resp = client.post("/api/admin/users", json={
+            "username": "kid", "password": "pw", "role": "reader",
+        })
+        assert resp.status_code == 409
+        assert count_users() == 1  # nothing created
+
+        # The install is still reachable, and first-run setup still works.
+        assert client.get("/api/admin/users").status_code == 200
+        assert client.post("/api/admin/setup-owner", json={
+            "username": "boss", "password": "hunter2",
+        }).status_code == 200
+        assert client.post("/api/admin/users", json={
+            "username": "kid", "password": "pw", "role": "reader",
+        }).status_code == 201
+
+    def test_owner_can_still_log_in_normally_afterwards(self, client, db_connection):
+        self._setup_owner(client)
+        client.post("/api/admin/users", json={
+            "username": "kid", "password": "pw", "role": "reader",
+        })
+        client.get("/logout")
+        assert client.get("/api/admin/users").status_code == 401
+        _login(client, "boss", "hunter2")
+        assert client.get("/api/admin/users").status_code == 200


### PR DESCRIPTION
## 📝 Description
Closes #444

Creating the second account is the thing that turns login on: `is_login_required()` is
`count_users() > 1`. Until that moment nobody has ever logged in — implicit-owner mode resolves
every request to the owner without a session, and `session["user_id"]` is only ever set by the
login form. So the create succeeds, the flip happens, and the owner's very next request is
anonymous. The page reports a failure and the browser is bounced to `/login` moments after the
account was created: the account is there, but it looks like it was not.

```
POST /api/admin/users  ->  201  (the account IS created)
GET  /api/admin/users  ->  401  {"error":"unauthorized"}
```

The fix persists the identity the browser was already acting under at the moment of the flip, so
the flip is invisible to the client that caused it. Only that browser is stamped, and only when it
was already resolving as the owner, so it gains nothing it did not hold a moment earlier — a
second, bystander client still gets a 401 and still has to log in. There is a test for that.

`routes/admin.py` holds the only call to `create_user()` outside first-run seeding, so that is the
whole of the runtime path that can turn login on.

### The same flip can lock an install permanently

Nothing forces the first-run `/setup-owner` screen, so the owner can still be the passwordless
`needs_setup` placeholder when the first extra account is added. Login turns on for an install
where no password exists to satisfy it, and `/setup-owner` is behind the same gate. Everyone is
locked out. This is reachable from a clean install by going straight to Settings → Users, and it
is what makes the reported bug worth more than a session tweak.

So the create is refused while the owner has no credentials, with a message saying what to do, and
the "Needs setup" badge on the users page now links to the screen that resolves it.

### …and there is a second way into the same dead end

`CLU_USERNAME`/`CLU_PASSWORD` is the documented way to require login — it is the commented-out pair
in `docker-compose.yaml`. Turning it on for an install that never ran first-run setup produces the
identical lockout, with no second account involved at all: the gate demands a login the owner
cannot give.

Worse, that pair is also the obvious thing to reach for to get *back* in, and it does not work.
`seed_owner_if_needed()` returns early whenever any user exists, so it reads the env vars only on
an empty database; the login form checks the `users` table, where the owner has no hash and the
configured username may match no row at all. Both dead ends are therefore recoverable only by
editing the database.

This PR makes the env vars do what an operator already expects: at startup an owner still flagged
`needs_setup` adopts them. That opens no door that was not already open — setting them takes
control of the container environment, which already implies full access to the database. A
configured owner is never overwritten, and a username already held by another account is left
alone: the owner keeps its own name and the log says so. When the vars are absent and the owner
still cannot log in, startup logs an error saying exactly that, instead of leaving the operator to
infer it from a login screen that rejects every password.

That last piece is what an install already broken by this bug needs — it cannot be fixed by
preventing the flip, only by making a way back in.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary — nothing to update; no new settings, no new dependencies
- [x] Verified build locally (`docker build -t dev .`)

Five files: the create-user route in `routes/admin.py`, owner seeding in `core/database.py`, the
badge and dialog handling in `templates/users.html`, and two test files.

## 📸 Screenshots / Logs

Containers built from identical inputs — `main` at d8e046e and this branch — each on a clean
`/config`, driven with `curl` over one cookie jar per scenario.

**A — the owner never ran first-run setup, then adds a user**

| | `main` | this branch |
| --- | --- | --- |
| `POST /api/admin/users` | `201` created | `409` refused, with the reason |
| `GET /api/admin/users` | `401 unauthorized` | `200` |
| `GET /config` | `302` → `/login` | `200` |
| owner can log back in | no — the account has no password | n/a, still login-free |

**B — the owner completes setup, then adds a user**

| | `main` | this branch |
| --- | --- | --- |
| `POST /api/admin/setup-owner` | `200` | `200` |
| `POST /api/admin/users` | `201` | `201` |
| `GET /api/admin/users` | `401 unauthorized` | `200` |
| `GET /config` | `302` → `/login` | `200` |

`main`'s `401` immediately after a `201` is exactly what the issue describes: "Failed to add User"
and the admin logged out, for an account that was in fact created.

**C — `CLU_USERNAME`/`CLU_PASSWORD` turned on for an install that never ran first-run setup**

| | `main` | this branch |
| --- | --- | --- |
| `POST /login` with those credentials | rejected | `302`, signed in |
| `GET /api/admin/users` | `401` | `200` |

**D — an install already locked out on `main`, then upgraded to this branch**

```
main:   POST /api/admin/users -> 201        # the install is now unreachable
branch, no env vars:   GET /config -> 302 -> /login
        ERROR  The Store Owner account has no password and this install requires login:
               nobody can sign in. Set CLU_USERNAME and CLU_PASSWORD and restart to give
               the owner credentials.
branch, with CLU_USERNAME / CLU_PASSWORD set:
        INFO   Store Owner 'envboss' adopted the credentials from CLU_USERNAME/CLU_PASSWORD
               (the account had none)
        POST /login -> 302 signed in;  GET /api/admin/users -> 200
```

**Driven through the real UI**, in headless Chrome over CDP against both images — a clean
install each time, clicking the actual buttons and typing into the actual fields.

On `main`, pressing **Save** in Add User leaves the page showing **"Failed to load users."** with
only `owner` in the table, while the database has gained the account:

```
users: [(1, 'owner', 'owner', needs_setup=1), (2, 'kid', 'reader', 0)]
```

That is the report verbatim — the add looks like it failed and the admin is signed out, for an
account that exists. `/setup-owner` then answers `/login?next=/setup-owner`, and no password
exists to get past it.

On this branch the same 16-step walkthrough passes end to end: the badge links to setup, the
premature create is refused and the dialog closes so the reason is readable, setup completes, the
account is added with **"Saved."** and both accounts listed, `/config` still opens, a second
browser is sent to `/login`, and the owner's new credentials sign in there.

## 🧪 Testing Performed
- [x] Manual test in `dev` container — the scenarios above, plus a full click-through of the UI
- [x] Linting/Unit tests pass

Fifteen new tests. Seven in `tests/routes/test_rbac.py`: the owner keeps the admin API and an
owner-only page across the flip; a bystander client is not signed in by someone else's create; a
placeholder owner cannot turn login on, nothing is created, and first-run setup still works
afterwards; the owner can still log out and back in normally once login is on; and a locked-out
install is driven back in through the real login form, ending on the admin pages. Three of those
fail on `main`. Eight in `tests/integration/test_users.py` cover the adoption: a placeholder owner
takes the env credentials, the env gate alone reaches it with no second account involved, a
configured owner keeps its own, a clashing `CLU_USERNAME` leaves both accounts intact, absent vars
change nothing, running it twice is a no-op, and the startup error fires when nobody can sign in —
and stays quiet while the install is still reachable.

The existing suite covers the untouched path — every `TestAdminUserApi` case creates its accounts
up front and logs in, so it exercises the already-multi-user install this PR must not change, and
`seed_owner_if_needed()`'s own tests pin the empty-database behaviour.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTCdHCCLmS4uMZG9NZWTz6
