### PR TITLE
Stop returning the account's password hash from the admin user API

### DIFF
--- a/routes/admin.py
+++ b/routes/admin.py
@@ -90,8 +90,16 @@ def put_browse_mode():
 
 
 def _user_payload(user):
-    """Attach the user's granted library ids and folder paths to a public dict."""
+    """Attach the user's granted library ids and folder paths to a public dict.
+
+    Drops the password hash: the create/update/setup responses build their
+    payload from get_user_by_id(), which is a ``SELECT *``, so without this the
+    hash is serialized into JSON and sent to the browser. list_users() already
+    selects a public column list, and this keeps every response saying the same
+    thing regardless of which accessor it came from.
+    """
     user = dict(user)
+    user.pop("password_hash", None)
     user["library_ids"] = sorted(get_user_library_ids(user["id"]))
     user["folder_paths"] = get_user_folder_paths(user["id"])
     return user

--- a/tests/routes/test_rbac.py
+++ b/tests/routes/test_rbac.py
@@ -10,8 +10,10 @@ import pytest
 from core.auth import required_role_for_request
 from core.database import (
     create_user,
+    delete_user,
     get_owner_user,
     get_user_by_username,
+    list_users,
     seed_owner_if_needed,
     verify_password,
 )
@@ -440,3 +442,71 @@ class TestSetupOwner:
             "username": "x", "password": "y",
         })
         assert resp.status_code == 409
+
+
+# ---------------------------------------------------------------------------
+# The admin user API must not hand out password hashes
+# ---------------------------------------------------------------------------
+class TestUserPayloadOmitsPasswordHash:
+    """Every account response says the same thing, whatever built it.
+
+    list_users() selects an explicit public column list, but the create, update
+    and setup-owner responses are built from get_user_by_id(), a ``SELECT *``.
+    These pin all four so the two paths cannot drift apart again.
+    """
+
+    PUBLIC = {"id", "username", "role", "is_active", "library_ids", "folder_paths"}
+
+    @pytest.fixture(autouse=True)
+    def _owner_and_login(self, db_connection, monkeypatch):
+        monkeypatch.delenv("CLU_USERNAME", raising=False)
+        monkeypatch.delenv("CLU_PASSWORD", raising=False)
+        create_user("owner", password="ownerpass", role="owner")
+        create_user("second", password="secondpass", role="reader")
+        yield
+
+    def _assert_clean(self, user):
+        assert "password_hash" not in user, f"password hash leaked: {sorted(user)}"
+        assert self.PUBLIC <= set(user), f"public fields missing: {sorted(user)}"
+
+    def test_create_response(self, client):
+        _login(client, "owner", "ownerpass")
+        resp = client.post("/api/admin/users", json={
+            "username": "kid", "password": "pw", "role": "reader",
+        })
+        assert resp.status_code == 201
+        self._assert_clean(resp.get_json()["user"])
+
+    def test_update_response(self, client):
+        _login(client, "owner", "ownerpass")
+        uid = get_user_by_username("second")["id"]
+        resp = client.put(f"/api/admin/users/{uid}", json={"role": "clerk"})
+        assert resp.status_code == 200
+        self._assert_clean(resp.get_json()["user"])
+
+    def test_list_response(self, client):
+        _login(client, "owner", "ownerpass")
+        for user in client.get("/api/admin/users").get_json()["users"]:
+            self._assert_clean(user)
+
+    def test_setup_owner_response(self, db_connection, client, monkeypatch):
+        """The first-run response, on an install with only the placeholder."""
+        monkeypatch.delenv("CLU_USERNAME", raising=False)
+        monkeypatch.delenv("CLU_PASSWORD", raising=False)
+        for user in list_users():
+            delete_user(user["id"])
+        seed_owner_if_needed()
+
+        resp = client.post("/api/admin/setup-owner", json={
+            "username": "boss", "password": "ownerpass",
+        })
+        assert resp.status_code == 200
+        self._assert_clean(resp.get_json()["user"])
+
+    def test_the_hash_is_still_stored(self, client):
+        """Dropping it from the response must not stop it being persisted."""
+        _login(client, "owner", "ownerpass")
+        client.post("/api/admin/users", json={
+            "username": "kid", "password": "pw", "role": "reader",
+        })
+        assert verify_password("kid", "pw")["role"] == "reader"


### PR DESCRIPTION
## 📝 Description
Closes #544

`list_users()` selects an explicit public column list and says in its docstring that it never
includes `password_hash`, so `GET /api/admin/users` is clean. The create, update and setup-owner
responses build their payload from `get_user_by_id()` instead — a `SELECT *` — so `_user_payload()`
copies the scrypt hash into the JSON and hands it to the browser.

It is not a credential: scrypt with a per-row salt, behind a Store Owner gate. That is why #544 is
filed in the open rather than through SECURITY.md. But it is a password hash leaving the server for
no reason, into somewhere it then travels — browser memory, devtools, HAR captures, and any screen
recording or bug report made from that tab. The project is careful about this everywhere else; the
debug package masks keys, passwords and tokens before they are attached to a support ticket.

The fix drops the field in `_user_payload()`, the single point all four responses pass through, so
they say the same thing regardless of which accessor built them and a fifth endpoint added later
inherits it rather than having to remember.

I left `get_user_by_id()` as a `SELECT *`. Its result also populates `g.current_user`, so the hash
still sits in request-local state where a template could reach it — nothing prints it today, but
nothing stops it either. Narrowing that accessor touches the auth path and every caller, and it
belongs in its own change; happy to write it if you would rather have it closed off at the source.

## 🛠️ Changes Made
- [x] Added new feature logic
- [ ] Updated Docker/Config if necessary — nothing to update; no new settings, no new dependencies
- [x] Verified build locally (`docker build -t dev .`)

Two files: `_user_payload()` in `routes/admin.py`, and the tests. +79 / −1.

## 📸 Screenshots / Logs

Two containers built from identical inputs — `main` at d8e046e and this branch — each on a clean
install, driven with `curl`. (`main`'s update call needs a real login first, because #444 signs the
owner out at exactly that point.)

| Response | `main` | this branch |
| --- | --- | --- |
| `POST /api/admin/setup-owner` | `password_hash` present | absent |
| `POST /api/admin/users` | `password_hash` present | absent |
| `PUT /api/admin/users/<id>` | `password_hash` present | absent |
| `GET /api/admin/users` | absent | absent |

```
main:   POST /api/admin/users -> 201
        {"success":true,"user":{…,"password_hash":"scrypt:32768:8:1$VKqV1Z5lG1I…"}}
branch: POST /api/admin/users -> 201
        {"success":true,"user":{…}}   # no password_hash
```

## 🧪 Testing Performed
- [x] Manual test in `dev` container — the table above
- [x] Linting/Unit tests pass

Five new tests in `tests/routes/test_rbac.py`, one per response plus two guards: that the public
fields the page needs are all still there, and that the hash is still *stored* — the account it
creates can still log in. Three of the five fail on `main`, which is exactly the three leaking
endpoints; the listing test and the persistence test pass either way and are there to keep the two
paths from drifting apart again.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTCdHCCLmS4uMZG9NZWTz6
